### PR TITLE
Sync interview config with backend account

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       # `pnpm test:main` stubs electron via module.registerHooks, added in Node 22.15.
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    name: Lint / type check / tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      # `pnpm test:main` stubs electron via module.registerHooks, added in Node 22.15.
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: ESLint
+        run: pnpm lint
+
+      - name: Type check (main process)
+        run: pnpm exec tsc -p tsconfig.electron.json --noEmit
+
+      - name: Type check (renderer)
+        run: pnpm exec tsc -b tsconfig.json
+
+      - name: Build renderer
+        run: pnpm exec vite build
+
+      - name: Main-process tests
+        run: pnpm test:main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,9 @@ pnpm format                    # Prettier + ESLint auto-fix
 pnpm test:main                 # Main-process checks (builds first; needs Node >= 22.15)
 ```
 
-There is no CI on push or pull request - `.github/workflows/release.yml` is `workflow_dispatch` only. Run lint, both `tsc` configs, and `pnpm test:main` locally before opening a PR.
+`.github/workflows/ci.yml` runs eslint, both `tsc` configs, the renderer build, and `pnpm test:main` on every pull request to `main`. Run the same locally first; CI is a backstop, not the first check. Releases are separate: `.github/workflows/release.yml` is `workflow_dispatch` only, so merging never publishes a build.
+
+Prettier is not enforced anywhere, and a number of files do not currently satisfy it, so `pnpm format` produces unrelated churn. Format the files you touch, not the tree.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,11 @@ pnpm electron:build            # Full distribution build via electron-builder
 
 pnpm lint                      # ESLint check
 pnpm format                    # Prettier + ESLint auto-fix
+
+pnpm test:main                 # Main-process checks (builds first; needs Node >= 22.15)
 ```
+
+There is no CI on push or pull request - `.github/workflows/release.yml` is `workflow_dispatch` only. Run lint, both `tsc` configs, and `pnpm test:main` locally before opening a PR.
 
 ## Architecture
 
@@ -46,7 +50,11 @@ Handler registration lives in [src/main/ipc/](src/main/ipc/) - one file per doma
 
 **AppState** ([src/renderer/hooks/use-app-state.tsx](src/renderer/hooks/use-app-state.tsx)) is read-only in the renderer. An `AppStateManager` singleton (pinned to `globalThis` to survive HMR) subscribes to `app-state-updated` push events from main; it falls back to 1-second polling when that API is unavailable. Never mutate AppState from the renderer - call the appropriate IPC method on main instead.
 
+`AppState` and what the renderer receives are not the same object. `appStateService.getRendererState()` reduces `interviewConfig` to a `{ fullName, hasProfileData }` summary, because the whole state is broadcast on every change and the profile and context can each run to 128,000 characters. Never put the full CV back into the broadcast - `test/app-state.test.mjs` pins this. The configuration dialog fetches the real values on demand over `account:get`.
+
 **ConfigStore** ([src/renderer/hooks/use-config-store.ts](src/renderer/hooks/use-config-store.ts)) is a Zustand store backed by the main-process Electron Store ([src/main/store/config.store.ts](src/main/store/config.store.ts)). Mutations call `window.electronAPI.config.update(...)` via IPC. A runtime migration IIFE at the bottom of the main store backfills newly-added keys on first launch.
+
+**Interview config** (full name, profile/CV, context) is *not* in ConfigStore - the backend account is its durable store, managed by [src/main/services/account.service.ts](src/main/services/account.service.ts) and pulled on login or a remembered session. A pre-sync `runtime.interviewConf` may still exist on disk from older builds; it is migrated onto the account and only deleted once the backend confirms the write, so do not drop it eagerly (`test/config-store.test.mjs` pins this).
 
 ### Transcription and Suggestion Flow
 

--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@
 
 ## Overview
 
-Power Interview is a privacy-first AI assistant designed to help you ace technical and behavioral interviews. With real-time transcription and intelligent suggestions, you'll have the confidence and support you need during live interviews-all while maintaining your privacy.
+Power Interview is a privacy-first AI assistant designed to help you ace technical and behavioral interviews. With real-time transcription and intelligent suggestions, you'll have the confidence and support you need during live interviews - all while keeping you in control of your data.
 
-## Privacy First
+## Privacy
 
-**Your data stays with you.** Power Interview is built with privacy as a core principle:
+Power Interview is built with privacy as a core principle. Here is exactly what is stored where:
 
-- **Client-Side Application**: Desktop client for account management and UI
-- **Secure Storage**: Credentials and personal info stored using Electron Store
-- **AI Processing**: Handled by secure backend services
-- **No Data Mining**: No selling or sharing personal data
-- **Minimal Data Transfer**: Only necessary data sent for AI suggestions
-- **Your Control**: CV, profile, and configs remain on your device
+- **Your interview configuration is stored on your account**: full name, CV/profile, and context are saved to the backend so they follow you across devices. You can change or clear them at any time from the configuration dialog
+- **Transcripts are never stored**: interview audio is relayed through the backend to the ASR provider for live transcription and is not retained; transcripts exist only in memory for the duration of the session
+- **Device settings stay on the device**: audio device, window bounds, and scroll preferences are local-only
+- **Local storage**: credentials and local settings are written by Electron Store to your OS user-data directory as a plain JSON file, protected by filesystem permissions
+- **No Data Mining**: no selling or sharing of personal data
+- **Minimal Data Transfer**: only the data needed for an active AI request, or an explicit configuration update, is sent to the backend
 
 ## Key Features
 
@@ -51,14 +51,14 @@ Stay on top of the conversation with live ASR:
 #### Action Suggestions
 
 - Screenshot-based problem understanding
-- Multi-image support (up to 3)
+- Multi-image support (up to 4)
 - LLM-powered solutions
 - Syntax-highlighted code output
 
 ### Smart Configuration
 
-- Profile management (CV, job description, etc.)
-- Audio device selection
+- Profile management (CV, job description, etc.), synced to your account across devices
+- Audio device selection (local to each device)
 - Language support (English)
 - Persistent settings
 
@@ -96,20 +96,29 @@ Power Interview follows a **client-server architecture**.
 
 ### Prerequisites
 
-- Node.js v18+ (v20 recommended)
+- Node.js v22.15+ (required by the main-process test runner)
+- pnpm (the repo pins `pnpm@11.1.3` via `packageManager`)
 
 ### Installation
 
 ```bash
 git clone https://github.com/PowerInterviewAI/client-app
-cd client
-npm install
+cd client-app
+pnpm install
 ```
 
 ### Run
 
 ```bash
-npm run start
+pnpm start
+```
+
+### Checks
+
+```bash
+pnpm lint          # ESLint
+pnpm build         # tsc + vite build (renderer)
+pnpm test:main     # main-process checks
 ```
 
 ### Configuration
@@ -138,10 +147,10 @@ npm run start
 
 ## Security & Privacy
 
-- Local encrypted storage
-- HTTPS + secure WebSockets
-- No external transcript storage
-- Full user control
+- HTTPS + secure WebSockets for all backend traffic
+- Interview configuration stored against your account; transcripts never persisted server-side
+- Local settings and credentials stored in your OS user-data directory
+- Full user control - configuration can be edited or cleared at any time
 
 ## Technology Stack
 
@@ -154,13 +163,17 @@ npm run start
 
 ### Backend
 
-- WebSocket
+- FastAPI (Python 3.12), MongoDB, Redis
+- REST over HTTPS and WebSocket streaming for ASR
 
 ## Project Structure
 
 ```
 power-interview-client/
 ├── src/
+│   ├── main/       Electron main process
+│   └── renderer/   React renderer
+├── test/           Main-process checks (pnpm test:main)
 ├── public/
 ├── build/
 ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -4,7 +4,7 @@ Project specification for Power Interview AI - a privacy-first AI-powered interv
 
 ## Overview
 
-Power Interview is an Electron desktop application that provides real-time transcription and AI suggestions during live job interviews. It runs entirely on the user's machine; no interview audio or transcripts are stored on external servers.
+Power Interview is an Electron desktop application that provides real-time transcription and AI suggestions during live job interviews. Audio is relayed through the backend to the ASR provider for transcription, but no interview audio or transcript is stored on external servers - transcripts exist only in memory for the duration of the session.
 
 ## Tech Stack
 
@@ -15,7 +15,8 @@ Power Interview is an Electron desktop application that provides real-time trans
 | Styling         | Tailwind CSS v4, shadcn/ui                  |
 | State           | Zustand (config), React Context (app state) |
 | Data fetching   | TanStack Query v5                           |
-| Persistence     | Electron Store                              |
+| HTTP            | Native `fetch`, main process only           |
+| Persistence     | Electron Store (local settings), backend account (interview config) |
 | Build/dist      | electron-builder, GitHub Releases           |
 | Package manager | pnpm                                        |
 
@@ -24,33 +25,39 @@ Power Interview is an Electron desktop application that provides real-time trans
 ```
 src/
   main/          Electron main process (Node.js)
-    api/         HTTP clients (AuthApi, LLMApi, PaymentApi, HealthCheckApi)
+    api/         HTTP clients (AuthApi, LLMApi, PaymentApi, HealthCheckApi, UsersApi)
     ipc/         IPC handler files, one per domain
     services/    Business logic called by IPC handlers
+    store/       config.store.ts - electron-store wrapper for local settings
     preload.cts  Exposes window.electronAPI to renderer
     consts.ts    Backend URL and other constants
   renderer/      React/Vite frontend
     hooks/       use-app-state.tsx (AppState), use-config-store.ts (ConfigStore)
     router.tsx   Hash-based router
+test/            Node-based checks for the main process (pnpm test:main)
 ```
 
 ## IPC Namespaces
 
-`window.electronAPI` exposes: `config`, `auth`, `payment`, `llm`, `appState`, `transcription`, `liveSuggestion`, `actionSuggestion`, `tools`, `window`, `autoUpdater`, `external`.
+`window.electronAPI` exposes the namespaces `config`, `auth`, `account`, `payment`, `llm`, `appState`, `transcription`, `liveSuggestion`, `actionSuggestion`, `tools`, `autoUpdater`, `zoom`, and `permissions`, plus flat window controls (`close`, `minimize`, `maximize`) and shell helpers (`openExternal`, `openFile`, `showInFolder`).
 
 ## Key Features
 
 ### Dual-Channel Transcription
 
-Real-time ASR via WebSocket streaming on two separate channels - speaker (system audio loopback) and interviewer (microphone). Service: [src/main/services/transcript-service.ts](src/main/services/transcript-service.ts).
+Real-time ASR via WebSocket streaming on two separate channels - the interviewer (`ch_0`, captured via system audio loopback) and the user (`ch_1`, captured via microphone). Service: [src/main/services/transcript.service.ts](src/main/services/transcript.service.ts).
 
 ### Live Suggestions
 
-Streaming AI responses generated from the user's CV and job description, triggered by live transcript context. Service: [src/main/services/live-suggestion-service.ts](src/main/services/live-suggestion-service.ts).
+Streaming AI responses generated from the user's CV and job description, triggered by live transcript context. Service: [src/main/services/suggestion-live.service.ts](src/main/services/suggestion-live.service.ts).
 
 ### Action Suggestions
 
-Screenshot-based problem solving. Accepts up to 3 images, sends them to the LLM backend, returns syntax-highlighted code output. Service: [src/main/services/action-suggestion-service.ts](src/main/services/action-suggestion-service.ts).
+Screenshot-based problem solving. Accepts up to 4 images, sends them to the LLM backend, returns syntax-highlighted code output. Service: [src/main/services/suggestion-action.service.ts](src/main/services/suggestion-action.service.ts).
+
+### Interview Config Sync
+
+Full name, profile/CV, and context are stored on the user's backend account and pulled on login or a remembered session, so the setup follows the user across devices. Service: [src/main/services/account.service.ts](src/main/services/account.service.ts). The full values are kept in the main process and fetched on demand over `account:get`; the app-state broadcast carries only a `{ fullName, hasProfileData }` summary, since the profile and context can each run to 128,000 characters.
 
 ### Credits and Payments
 
@@ -62,9 +69,9 @@ electron-updater publishes to GitHub Releases under `PowerInterviewAI/client` (c
 
 ## Backend Communication
 
-- REST (HTTP): auth, payment, LLM suggestions
+- REST (HTTP): auth, account / interview config (`/api/users`), payment, LLM suggestions
 - WebSocket: real-time transcription streaming
-- API client: [src/main/api/client.ts](src/main/api/client.ts) - fetch-based, Bearer token auth, streaming support
+- API client: [src/main/api/client.ts](src/main/api/client.ts) - fetch-based, Bearer token auth, streaming support. Request timeouts are opt-in per call via `timeoutMs` (health-check pings use 10s, `UsersApi` 30s); `requestStream` is deliberately untimed, since suggestion streams are long-lived
 
 ## Privacy Model
 
@@ -72,8 +79,8 @@ electron-updater publishes to GitHub Releases under `PowerInterviewAI/client` (c
   user's account so it follows them across devices - it is not kept on local disk
 - Device-specific settings (audio device, window bounds, scroll preferences) stay on the device
 - Only the minimum data needed for AI suggestions is sent to the backend
-- No transcript storage on external servers
-- Credentials encrypted via Electron Store
+- No transcript storage on external servers - transcripts stay in memory for the session
+- Credentials are stored locally by Electron Store in the OS user-data directory. No encryption key is configured, so the file is plain JSON protected by filesystem permissions
 
 ## Platform Support
 
@@ -87,6 +94,7 @@ power-interview-client/
   src/
     main/
     renderer/
+  test/           Main-process checks, run with `pnpm test:main` (needs Node >= 22.15)
   public/
   build/          Build resources (icons, entitlements)
   release/        electron-builder output (gitignored)

--- a/SPEC.md
+++ b/SPEC.md
@@ -68,7 +68,9 @@ electron-updater publishes to GitHub Releases under `PowerInterviewAI/client` (c
 
 ## Privacy Model
 
-- CV, job description, and config stay on the user's device (Electron Store)
+- Interview configuration (full name, CV/profile, context) is stored on the backend against the
+  user's account so it follows them across devices - it is not kept on local disk
+- Device-specific settings (audio device, window bounds, scroll preferences) stay on the device
 - Only the minimum data needed for AI suggestions is sent to the backend
 - No transcript storage on external servers
 - Credentials encrypted via Electron Store

--- a/SPEC.md
+++ b/SPEC.md
@@ -61,7 +61,7 @@ Full name, profile/CV, and context are stored on the user's backend account and 
 
 ### Credits and Payments
 
-Purchase and usage tracking via the payment API. Route: `/payment`.
+Purchase and usage tracking via the payment API. Route: `/payment`. Plans and the credit balance are always served by the backend (`/api/payment/plans`, `/api/payment/credits`, plus the balance carried on every 5-second `/api/health-check/ping-client`); the client holds no local pricing, so a failed plan fetch surfaces as an error rather than falling back to stale figures.
 
 ### Auto-Updates
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "electron:build": "pnpm electron:build-main && pnpm build && electron-builder",
     "lint": "eslint .",
     "format": "prettier --write . && eslint --fix .",
+    "test:main": "pnpm electron:build-main && node test/run.mjs",
     "start": "pnpm electron:dev-hide"
   },
   "dependencies": {

--- a/src/main/api/client.ts
+++ b/src/main/api/client.ts
@@ -118,6 +118,11 @@ export class ApiClient {
     return this.request<T>('PUT', url, body);
   }
 
+  async patch<T>(path: string, body?: unknown): Promise<ApiResponse<T>> {
+    const url = this.buildUrl(path);
+    return this.request<T>('PATCH', url, body);
+  }
+
   async delete<T>(path: string): Promise<ApiResponse<T>> {
     const url = this.buildUrl(path);
     return this.request<T>('DELETE', url);

--- a/src/main/api/client.ts
+++ b/src/main/api/client.ts
@@ -107,9 +107,9 @@ export class ApiClient {
     }
   }
 
-  async post<T>(path: string, body?: unknown): Promise<ApiResponse<T>> {
+  async post<T>(path: string, body?: unknown, timeoutMs?: number): Promise<ApiResponse<T>> {
     const url = this.buildUrl(path);
-    return this.request<T>('POST', url, body);
+    return this.request<T>('POST', url, body, timeoutMs);
   }
 
   async postStream(path: string, body?: unknown): Promise<ReadableStream<Uint8Array> | null> {

--- a/src/main/api/client.ts
+++ b/src/main/api/client.ts
@@ -51,9 +51,13 @@ export class ApiClient {
     delete this.headers['Authorization'];
   }
 
-  async get<T>(path: string, params?: Record<string, unknown>): Promise<ApiResponse<T>> {
+  async get<T>(
+    path: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number
+  ): Promise<ApiResponse<T>> {
     const url = this.buildUrl(path, params);
-    return this.request<T>('GET', url);
+    return this.request<T>('GET', url, undefined, timeoutMs);
   }
 
   async postFormData<T>(path: string, formData: FormData): Promise<ApiResponse<T>> {
@@ -118,9 +122,9 @@ export class ApiClient {
     return this.request<T>('PUT', url, body);
   }
 
-  async patch<T>(path: string, body?: unknown): Promise<ApiResponse<T>> {
+  async patch<T>(path: string, body?: unknown, timeoutMs?: number): Promise<ApiResponse<T>> {
     const url = this.buildUrl(path);
-    return this.request<T>('PATCH', url, body);
+    return this.request<T>('PATCH', url, body, timeoutMs);
   }
 
   async delete<T>(path: string): Promise<ApiResponse<T>> {
@@ -128,7 +132,12 @@ export class ApiClient {
     return this.request<T>('DELETE', url);
   }
 
-  private async request<T>(method: string, url: string, body?: unknown): Promise<ApiResponse<T>> {
+  private async request<T>(
+    method: string,
+    url: string,
+    body?: unknown,
+    timeoutMs?: number
+  ): Promise<ApiResponse<T>> {
     try {
       const sessionToken = configStore.getConfig().sessionToken;
       if (sessionToken) {
@@ -139,6 +148,7 @@ export class ApiClient {
         method,
         headers: this.headers,
         body: body ? JSON.stringify(body) : undefined,
+        signal: timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined,
       });
 
       const respBody = await response.json().catch(() => ({}));
@@ -159,11 +169,16 @@ export class ApiClient {
         data: respBody,
       };
     } catch (error: unknown) {
+      const timedOut = error instanceof Error && error.name === 'TimeoutError';
       return {
         status: 0,
         error: {
-          code: 'NETWORK_ERROR',
-          message: error instanceof Error ? error.message : 'Network request failed',
+          code: timedOut ? 'TIMEOUT' : 'NETWORK_ERROR',
+          message: timedOut
+            ? 'The request timed out'
+            : error instanceof Error
+              ? error.message
+              : 'Network request failed',
         },
       };
     }

--- a/src/main/api/health-check.ts
+++ b/src/main/api/health-check.ts
@@ -7,12 +7,17 @@ import { RunningState } from '../types/app-state.js';
 import { ClientPingRequest, ClientPingResponse } from '../types/health-check.js';
 import { ApiClient, ApiResponse } from './client.js';
 
+// Shorter than the 5s success interval, so a stalled socket cannot outlive a tick. The initial
+// pingClient() is awaited before the liveness and 401 loops start, and HealthCheckService.start()
+// is itself awaited during app startup, so without this a single stall holds both back.
+const PING_TIMEOUT_MS = 4_000;
+
 export class HealthCheckApi extends ApiClient {
   /**
    * Health check / ping
    */
   async ping(): Promise<ApiResponse<string>> {
-    return this.get('/api/health-check/ping');
+    return this.get('/api/health-check/ping', undefined, PING_TIMEOUT_MS);
   }
 
   /**
@@ -20,8 +25,12 @@ export class HealthCheckApi extends ApiClient {
    */
   async pingClient(): Promise<ApiResponse<ClientPingResponse>> {
     const appState = appStateService.getState();
-    return this.post<ClientPingResponse>('/api/health-check/ping-client', {
-      is_assistant_running: appState.runningState === RunningState.Running,
-    } as ClientPingRequest);
+    return this.post<ClientPingResponse>(
+      '/api/health-check/ping-client',
+      {
+        is_assistant_running: appState.runningState === RunningState.Running,
+      } as ClientPingRequest,
+      PING_TIMEOUT_MS
+    );
   }
 }

--- a/src/main/api/health-check.ts
+++ b/src/main/api/health-check.ts
@@ -7,10 +7,14 @@ import { RunningState } from '../types/app-state.js';
 import { ClientPingRequest, ClientPingResponse } from '../types/health-check.js';
 import { ApiClient, ApiResponse } from './client.js';
 
-// Shorter than the 5s success interval, so a stalled socket cannot outlive a tick. The initial
-// pingClient() is awaited before the liveness and 401 loops start, and HealthCheckService.start()
-// is itself awaited during app startup, so without this a single stall holds both back.
-const PING_TIMEOUT_MS = 4_000;
+// The initial pingClient() is awaited before the liveness and 401 loops start, and
+// HealthCheckService.start() is itself awaited during app startup, so without a bound here a
+// single stalled socket holds both back for as long as the runtime's default allows.
+//
+// Generous rather than tight: the loops await each ping and only then sleep, so this never
+// overlaps a tick, and ping-client authenticates against the database. Cutting it close to the
+// 5s interval would report a slow-but-alive backend as down on a high-latency connection.
+const PING_TIMEOUT_MS = 10_000;
 
 export class HealthCheckApi extends ApiClient {
   /**

--- a/src/main/api/users.ts
+++ b/src/main/api/users.ts
@@ -1,0 +1,24 @@
+/**
+ * Users API
+ * Handles the authenticated user's account and interview configuration
+ * (full name, profile, context)
+ */
+
+import { UpdateInterviewConfigRequest, UserAccount } from '../types/account.js';
+import { ApiClient, ApiResponse } from './client.js';
+
+export class UsersApi extends ApiClient {
+  /**
+   * Get the authenticated user's account
+   */
+  async getMe(): Promise<ApiResponse<UserAccount>> {
+    return this.get<UserAccount>('/api/users/me');
+  }
+
+  /**
+   * Replace the authenticated user's interview configuration
+   */
+  async updateInterviewConfig(data: UpdateInterviewConfigRequest): Promise<ApiResponse<UserAccount>> {
+    return this.patch<UserAccount>('/api/users/me/interview-config', data);
+  }
+}

--- a/src/main/api/users.ts
+++ b/src/main/api/users.ts
@@ -7,18 +7,22 @@
 import { UpdateInterviewConfigRequest, UserAccount } from '../types/account.js';
 import { ApiClient, ApiResponse } from './client.js';
 
+// These carry the full profile/context payload, so allow well over a plain JSON round-trip,
+// but never let a stalled socket leave the request pending forever.
+const REQUEST_TIMEOUT_MS = 30_000;
+
 export class UsersApi extends ApiClient {
   /**
    * Get the authenticated user's account
    */
   async getMe(): Promise<ApiResponse<UserAccount>> {
-    return this.get<UserAccount>('/api/users/me');
+    return this.get<UserAccount>('/api/users/me', undefined, REQUEST_TIMEOUT_MS);
   }
 
   /**
    * Replace the authenticated user's interview configuration
    */
   async updateInterviewConfig(data: UpdateInterviewConfigRequest): Promise<ApiResponse<UserAccount>> {
-    return this.patch<UserAccount>('/api/users/me/interview-config', data);
+    return this.patch<UserAccount>('/api/users/me/interview-config', data, REQUEST_TIMEOUT_MS);
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,6 +8,7 @@ const __dirname = path.dirname(__filename);
 // Import modules
 import { MIN_HEIGHT, MIN_WIDTH } from './consts.js';
 import { registerGlobalHotkeys, unregisterHotkeys } from './hotkeys.js';
+import { registerAccountHandlers } from './ipc/account.js';
 import { registerAppStateHandlers } from './ipc/app-state.js';
 import { registerAuthHandlers } from './ipc/auth.js';
 import { registerAutoUpdaterHandlers } from './ipc/auto-updater.js';
@@ -182,6 +183,7 @@ app.whenReady().then(async () => {
   registerConfigHandlers();
   registerAppStateHandlers();
   registerAuthHandlers();
+  registerAccountHandlers();
   registerPaymentHandlers();
   registerLLMHandlers();
   registerPermissionHandlers();

--- a/src/main/ipc/account.ts
+++ b/src/main/ipc/account.ts
@@ -1,0 +1,13 @@
+import { ipcMain } from 'electron';
+
+import { accountService } from '../services/account.service.js';
+
+export function registerAccountHandlers(): void {
+  // Push local account config changes (full name, profile, context) to the backend
+  ipcMain.handle(
+    'account:update',
+    async (_event, fullName: string, profileData: string, context: string) => {
+      return accountService.updateConfig(fullName, profileData, context);
+    }
+  );
+}

--- a/src/main/ipc/account.ts
+++ b/src/main/ipc/account.ts
@@ -15,4 +15,10 @@ export function registerAccountHandlers(): void {
   ipcMain.handle('account:refresh', async () => {
     return accountService.pullFromBackend();
   });
+
+  // Full config for the configuration dialog; kept out of the app-state broadcast because
+  // the profile and context can run to hundreds of KB.
+  ipcMain.handle('account:get', async () => {
+    return accountService.getEditableConfig();
+  });
 }

--- a/src/main/ipc/account.ts
+++ b/src/main/ipc/account.ts
@@ -10,4 +10,9 @@ export function registerAccountHandlers(): void {
       return accountService.updateConfig(fullName, profileData, context);
     }
   );
+
+  // Retry the initial pull when it failed at startup (offline, backend down)
+  ipcMain.handle('account:refresh', async () => {
+    return accountService.pullFromBackend();
+  });
 }

--- a/src/main/ipc/app-state.ts
+++ b/src/main/ipc/app-state.ts
@@ -9,12 +9,12 @@ import { appStateService } from '../services/app-state.service.js';
 export function registerAppStateHandlers(): void {
   // Get current app state
   ipcMain.handle('app:get-state', async () => {
-    return appStateService.getState();
+    return appStateService.getRendererState();
   });
 
   // Update app state
   ipcMain.handle('app:update-state', async (_event, updates) => {
     appStateService.updateState(updates);
-    return appStateService.getState();
+    return appStateService.getRendererState();
   });
 }

--- a/src/main/preload.cts
+++ b/src/main/preload.cts
@@ -53,6 +53,11 @@ const electronApi = {
       ipcRenderer.invoke('auth:change-password', currentPassword, newPassword),
   },
 
+  account: {
+    update: (fullName: string, profileData: string, context: string) =>
+      ipcRenderer.invoke('account:update', fullName, profileData, context),
+  },
+
   payment: {
     getPlans: () => ipcRenderer.invoke('payment:get-plans'),
     getCurrencies: () => ipcRenderer.invoke('payment:get-currencies'),

--- a/src/main/preload.cts
+++ b/src/main/preload.cts
@@ -56,6 +56,7 @@ const electronApi = {
   account: {
     update: (fullName: string, profileData: string, context: string) =>
       ipcRenderer.invoke('account:update', fullName, profileData, context),
+    refresh: () => ipcRenderer.invoke('account:refresh'),
   },
 
   payment: {

--- a/src/main/preload.cts
+++ b/src/main/preload.cts
@@ -57,6 +57,7 @@ const electronApi = {
     update: (fullName: string, profileData: string, context: string) =>
       ipcRenderer.invoke('account:update', fullName, profileData, context),
     refresh: () => ipcRenderer.invoke('account:refresh'),
+    get: () => ipcRenderer.invoke('account:get'),
   },
 
   payment: {

--- a/src/main/services/account.service.ts
+++ b/src/main/services/account.service.ts
@@ -1,18 +1,20 @@
 import { UsersApi } from '../api/users.js';
-import { configStore } from '../store/config.store.js';
+import { appStateService } from './app-state.service.js';
 
 /**
  * AccountService
- * Keeps the local interviewConf (full name, profile, context) in sync with the
- * account persisted on the backend, so this config follows the user across devices.
+ * Keeps the in-memory interview config (full name, profile, context) in sync with
+ * the account persisted on the backend. Not written to local disk - the backend is
+ * the only durable store, so this always reflects whatever was last fetched/saved
+ * this session.
  */
 export class AccountService {
   private client = new UsersApi();
 
   /**
-   * Pull the authenticated user's persisted account config from the backend
-   * into the local store. Called after login so a device shows the same
-   * config the user last saved anywhere.
+   * Pull the authenticated user's persisted interview config from the backend
+   * into app state. Called after login so a device shows the same config the
+   * user last saved anywhere.
    */
   async pullFromBackend(): Promise<{ success: boolean; error?: string }> {
     try {
@@ -22,8 +24,8 @@ export class AccountService {
       }
 
       const interviewConfig = response.data.interview_config;
-      configStore.updateConfig({
-        interviewConf: {
+      appStateService.updateState({
+        interviewConfig: {
           fullName: interviewConfig?.full_name ?? '',
           profileData: interviewConfig?.profile_data ?? '',
           context: interviewConfig?.context ?? '',
@@ -37,7 +39,7 @@ export class AccountService {
 
   /**
    * Push local interview config changes to the backend, then mirror the
-   * saved values into the local store.
+   * saved values into app state.
    */
   async updateConfig(
     fullName: string,
@@ -54,7 +56,7 @@ export class AccountService {
         return { success: false, error: response.error.message || 'Failed to update account' };
       }
 
-      configStore.updateConfig({ interviewConf: { fullName, profileData, context } });
+      appStateService.updateState({ interviewConfig: { fullName, profileData, context } });
       return { success: true };
     } catch {
       return { success: false, error: 'Failed to update account' };

--- a/src/main/services/account.service.ts
+++ b/src/main/services/account.service.ts
@@ -1,0 +1,65 @@
+import { UsersApi } from '../api/users.js';
+import { configStore } from '../store/config.store.js';
+
+/**
+ * AccountService
+ * Keeps the local interviewConf (full name, profile, context) in sync with the
+ * account persisted on the backend, so this config follows the user across devices.
+ */
+export class AccountService {
+  private client = new UsersApi();
+
+  /**
+   * Pull the authenticated user's persisted account config from the backend
+   * into the local store. Called after login so a device shows the same
+   * config the user last saved anywhere.
+   */
+  async pullFromBackend(): Promise<{ success: boolean; error?: string }> {
+    try {
+      const response = await this.client.getMe();
+      if (response.error || !response.data) {
+        return { success: false, error: response.error?.message || 'Failed to fetch account' };
+      }
+
+      const interviewConfig = response.data.interview_config;
+      configStore.updateConfig({
+        interviewConf: {
+          fullName: interviewConfig?.full_name ?? '',
+          profileData: interviewConfig?.profile_data ?? '',
+          context: interviewConfig?.context ?? '',
+        },
+      });
+      return { success: true };
+    } catch {
+      return { success: false, error: 'Failed to fetch account' };
+    }
+  }
+
+  /**
+   * Push local interview config changes to the backend, then mirror the
+   * saved values into the local store.
+   */
+  async updateConfig(
+    fullName: string,
+    profileData: string,
+    context: string
+  ): Promise<{ success: boolean; error?: string }> {
+    try {
+      const response = await this.client.updateInterviewConfig({
+        full_name: fullName,
+        profile_data: profileData,
+        context,
+      });
+      if (response.error) {
+        return { success: false, error: response.error.message || 'Failed to update account' };
+      }
+
+      configStore.updateConfig({ interviewConf: { fullName, profileData, context } });
+      return { success: true };
+    } catch {
+      return { success: false, error: 'Failed to update account' };
+    }
+  }
+}
+
+export const accountService = new AccountService();

--- a/src/main/services/account.service.ts
+++ b/src/main/services/account.service.ts
@@ -1,5 +1,11 @@
 import { UsersApi } from '../api/users.js';
-import { clearLegacyInterviewConf, getLegacyInterviewConf } from '../store/config.store.js';
+import {
+  claimLegacyInterviewConf,
+  clearLegacyInterviewConf,
+  getLegacyInterviewConf,
+  getLegacyInterviewConfOwner,
+} from '../store/config.store.js';
+import { InterviewConfig } from '../types/app-state.js';
 import { appStateService } from './app-state.service.js';
 
 /**
@@ -11,9 +17,6 @@ import { appStateService } from './app-state.service.js';
  */
 export class AccountService {
   private client = new UsersApi();
-
-  /** Account the leftover pre-sync config was offered to; see migrateLegacyConfig(). */
-  private migrationOwnerId: string | null = null;
 
   /**
    * Pull the authenticated user's persisted interview config from the backend
@@ -65,9 +68,9 @@ export class AccountService {
    *
    * The leftover copy is device-scoped, not account-scoped, so the first account offered
    * it claims it and it is never pushed anywhere else. Without that claim, a second
-   * sign-in on the same process - a new signup, or another user on a shared machine -
-   * would inherit the first user's CV, because a failed push deliberately keeps the copy
-   * around for retry.
+   * sign-in - a new signup, or another user on a shared machine - would inherit the first
+   * user's CV, because a failed push deliberately keeps the copy around for retry. The
+   * claim is persisted, since that retry can happen in a later run of the app.
    */
   private async migrateLegacyConfig(accountId: string): Promise<'migrated' | 'failed' | 'none'> {
     const legacy = getLegacyInterviewConf();
@@ -76,8 +79,12 @@ export class AccountService {
     const context = legacy?.jobDescription ?? '';
     if (!fullName && !profileData && !context) return 'none';
 
-    this.migrationOwnerId ??= accountId;
-    if (this.migrationOwnerId !== accountId) return 'none';
+    const owner = getLegacyInterviewConfOwner();
+    if (owner === null) {
+      claimLegacyInterviewConf(accountId);
+    } else if (owner !== accountId) {
+      return 'none';
+    }
 
     const result = await this.updateConfig(fullName, profileData, context);
     if (!result.success) {
@@ -114,14 +121,45 @@ export class AccountService {
         return { success: false, error: response.error.message || 'Failed to update account' };
       }
 
+      // Mirror what the backend stored, not what was sent: it truncates oversized fields,
+      // so echoing the request would leave the app showing a value the account does not have.
+      const saved = response.data?.interview_config;
       appStateService.updateState({
-        interviewConfig: { fullName, profileData, context },
+        interviewConfig: {
+          fullName: saved?.full_name ?? fullName,
+          profileData: saved?.profile_data ?? profileData,
+          context: saved?.context ?? context,
+        },
         interviewConfigLoaded: true,
       });
       return { success: true };
     } catch {
       return { success: false, error: 'Failed to update account' };
     }
+  }
+
+  /**
+   * Full interview config for the configuration dialog.
+   *
+   * Always refreshes first: a save replaces the whole config, so editing a copy another device
+   * has since changed would silently discard that change. `success` reports whether the values
+   * are safe to save over - false when nothing was ever loaded this session, in which case the
+   * data returned is a local leftover or blank and must not be pushed back to the account.
+   */
+  async getEditableConfig(): Promise<{
+    success: boolean;
+    data: InterviewConfig;
+    error?: string;
+  }> {
+    const pull = await this.pullFromBackend();
+    const state = appStateService.getState();
+    const loaded = state.interviewConfigLoaded;
+
+    return {
+      success: loaded,
+      data: state.interviewConfig,
+      error: loaded ? undefined : pull.error || 'Failed to load configuration',
+    };
   }
 
   /**

--- a/src/main/services/account.service.ts
+++ b/src/main/services/account.service.ts
@@ -51,7 +51,7 @@ export class AccountService {
         },
         interviewConfigLoaded: true,
       });
-      if (interviewConfig) clearLegacyInterviewConf();
+      if (interviewConfig) this.discardLegacyConfigIfOwned(account._id);
       return { success: true };
     } catch {
       return { success: false, error: 'Failed to fetch account' };
@@ -103,6 +103,20 @@ export class AccountService {
   }
 
   /**
+   * Drop the pre-sync copy now that this account carries its own config.
+   *
+   * Gated on the claim: an unclaimed copy belongs to the first account offered it, same rule
+   * migrateLegacyConfig applies, so this account may discard it. A copy claimed by a different
+   * account is a migration that has not finished - a failed push deliberately keeps it for
+   * retry - and deleting it here would lose that user's CV on a shared machine.
+   */
+  private discardLegacyConfigIfOwned(accountId: string): void {
+    const owner = getLegacyInterviewConfOwner();
+    if (owner !== null && owner !== accountId) return;
+    clearLegacyInterviewConf();
+  }
+
+  /**
    * Push local interview config changes to the backend, then mirror the
    * saved values into app state.
    */
@@ -143,8 +157,11 @@ export class AccountService {
    *
    * Always refreshes first: a save replaces the whole config, so editing a copy another device
    * has since changed would silently discard that change. `success` reports whether the values
-   * are safe to save over - false when nothing was ever loaded this session, in which case the
-   * data returned is a local leftover or blank and must not be pushed back to the account.
+   * are safe to save over, and requires *this* refresh to have succeeded - not just that
+   * something was loaded earlier in the session. `interviewConfigLoaded` survives a failed pull
+   * by design (it gates Start, which should keep working on a blip), so trusting it alone would
+   * hand the dialog a stale copy with Save enabled and no warning, which is exactly how a newer
+   * config saved on another device gets overwritten.
    */
   async getEditableConfig(): Promise<{
     success: boolean;
@@ -153,12 +170,12 @@ export class AccountService {
   }> {
     const pull = await this.pullFromBackend();
     const state = appStateService.getState();
-    const loaded = state.interviewConfigLoaded;
+    const fresh = pull.success && state.interviewConfigLoaded;
 
     return {
-      success: loaded,
+      success: fresh,
       data: state.interviewConfig,
-      error: loaded ? undefined : pull.error || 'Failed to load configuration',
+      error: fresh ? undefined : pull.error || 'Failed to load configuration',
     };
   }
 

--- a/src/main/services/account.service.ts
+++ b/src/main/services/account.service.ts
@@ -137,6 +137,12 @@ export class AccountService {
    * migrateLegacyConfig applies, so this account may discard it. A copy claimed by a different
    * account is a migration that has not finished - a failed push deliberately keeps it for
    * retry - and deleting it here would lose that user's CV on a shared machine.
+   *
+   * Discarding an unclaimed copy does lose it: a user who upgrades a second device whose
+   * account already synced from the first never sees that device's older local CV again. That
+   * is the intended trade. Keeping it would leave it eligible for migration, and the next
+   * account to sign in with an empty config would claim and inherit it - the cross-account
+   * leak the claim exists to prevent. Losing a superseded copy beats leaking a live one.
    */
   private discardLegacyConfigIfOwned(accountId: string): void {
     const owner = getLegacyInterviewConfOwner();

--- a/src/main/services/account.service.ts
+++ b/src/main/services/account.service.ts
@@ -19,11 +19,23 @@ export class AccountService {
   private client = new UsersApi();
 
   /**
+   * Bumped by every write to the config in app state.
+   *
+   * The startup pull is deliberately unawaited and can take up to the 30s request timeout, so
+   * it can still be in flight when the user saves from the dialog. Applying its response then
+   * would put the pre-save config back, and nothing shows it: the dialog is already closed, and
+   * the suggestion services read the config straight out of app state, so the rest of the
+   * session runs on the old CV.
+   */
+  private generation = 0;
+
+  /**
    * Pull the authenticated user's persisted interview config from the backend
    * into app state. Called after login so a device shows the same config the
    * user last saved anywhere.
    */
   async pullFromBackend(): Promise<{ success: boolean; error?: string }> {
+    const generation = this.generation;
     try {
       const response = await this.client.getMe();
       if (response.error || !response.data) {
@@ -42,6 +54,13 @@ export class AccountService {
           return { success: false, error: 'Failed to migrate local configuration' };
         }
       }
+
+      // A save, a logout or a later pull landed while this request was in flight. Its result is
+      // the newer one, so drop this response rather than reverting to what the account held
+      // when this pull started. Reported as success: the fetch itself worked, and the config
+      // in state is loaded and current.
+      if (generation !== this.generation) return { success: true };
+      this.generation++;
 
       appStateService.updateState({
         interviewConfig: {
@@ -138,6 +157,7 @@ export class AccountService {
       // Mirror what the backend stored, not what was sent: it truncates oversized fields,
       // so echoing the request would leave the app showing a value the account does not have.
       const saved = response.data?.interview_config;
+      this.generation++;
       appStateService.updateState({
         interviewConfig: {
           fullName: saved?.full_name ?? fullName,
@@ -185,6 +205,7 @@ export class AccountService {
    * whenever their post-login pull fails, and can overwrite their own account with it.
    */
   clearState(): void {
+    this.generation++;
     appStateService.updateState({
       interviewConfig: { fullName: '', profileData: '', context: '' },
       interviewConfigLoaded: false,

--- a/src/main/services/account.service.ts
+++ b/src/main/services/account.service.ts
@@ -1,4 +1,5 @@
 import { UsersApi } from '../api/users.js';
+import { clearLegacyInterviewConf, legacyInterviewConf } from '../store/config.store.js';
 import { appStateService } from './app-state.service.js';
 
 /**
@@ -24,17 +25,45 @@ export class AccountService {
       }
 
       const interviewConfig = response.data.interview_config;
+
+      // Pre-sync builds kept this config on local disk only. If the account has none yet,
+      // adopt the leftover local copy instead of presenting the user an empty profile.
+      if (!interviewConfig) {
+        const migrated = await this.migrateLegacyConfig();
+        if (migrated) return { success: true };
+      }
+
       appStateService.updateState({
         interviewConfig: {
           fullName: interviewConfig?.full_name ?? '',
           profileData: interviewConfig?.profile_data ?? '',
           context: interviewConfig?.context ?? '',
         },
+        interviewConfigLoaded: true,
       });
+      if (interviewConfig) clearLegacyInterviewConf();
       return { success: true };
     } catch {
       return { success: false, error: 'Failed to fetch account' };
     }
+  }
+
+  /**
+   * Push a pre-sync local config up to the account, once. The local copy is only
+   * dropped after the backend confirms the write, so a failed migration is retried
+   * on the next launch rather than losing the user's profile.
+   */
+  private async migrateLegacyConfig(): Promise<boolean> {
+    const fullName = legacyInterviewConf?.username ?? '';
+    const profileData = legacyInterviewConf?.profileData ?? '';
+    const context = legacyInterviewConf?.jobDescription ?? '';
+    if (!fullName && !profileData && !context) return false;
+
+    const result = await this.updateConfig(fullName, profileData, context);
+    if (!result.success) return false;
+
+    clearLegacyInterviewConf();
+    return true;
   }
 
   /**
@@ -56,7 +85,10 @@ export class AccountService {
         return { success: false, error: response.error.message || 'Failed to update account' };
       }
 
-      appStateService.updateState({ interviewConfig: { fullName, profileData, context } });
+      appStateService.updateState({
+        interviewConfig: { fullName, profileData, context },
+        interviewConfigLoaded: true,
+      });
       return { success: true };
     } catch {
       return { success: false, error: 'Failed to update account' };

--- a/src/main/services/account.service.ts
+++ b/src/main/services/account.service.ts
@@ -1,5 +1,5 @@
 import { UsersApi } from '../api/users.js';
-import { clearLegacyInterviewConf, legacyInterviewConf } from '../store/config.store.js';
+import { clearLegacyInterviewConf, getLegacyInterviewConf } from '../store/config.store.js';
 import { appStateService } from './app-state.service.js';
 
 /**
@@ -11,6 +11,9 @@ import { appStateService } from './app-state.service.js';
  */
 export class AccountService {
   private client = new UsersApi();
+
+  /** Account the leftover pre-sync config was offered to; see migrateLegacyConfig(). */
+  private migrationOwnerId: string | null = null;
 
   /**
    * Pull the authenticated user's persisted interview config from the backend
@@ -24,12 +27,13 @@ export class AccountService {
         return { success: false, error: response.error?.message || 'Failed to fetch account' };
       }
 
-      const interviewConfig = response.data.interview_config;
+      const account = response.data;
+      const interviewConfig = account.interview_config;
 
       // Pre-sync builds kept this config on local disk only. If the account has none yet,
       // adopt the leftover local copy instead of presenting the user an empty profile.
       if (!interviewConfig) {
-        const migration = await this.migrateLegacyConfig();
+        const migration = await this.migrateLegacyConfig(account._id);
         if (migration === 'migrated') return { success: true };
         if (migration === 'failed') {
           return { success: false, error: 'Failed to migrate local configuration' };
@@ -58,12 +62,22 @@ export class AccountService {
    *
    * 'none' means there was nothing local to migrate, which is distinct from a push
    * that failed: only the former should leave the user looking at a blank profile.
+   *
+   * The leftover copy is device-scoped, not account-scoped, so the first account offered
+   * it claims it and it is never pushed anywhere else. Without that claim, a second
+   * sign-in on the same process - a new signup, or another user on a shared machine -
+   * would inherit the first user's CV, because a failed push deliberately keeps the copy
+   * around for retry.
    */
-  private async migrateLegacyConfig(): Promise<'migrated' | 'failed' | 'none'> {
-    const fullName = legacyInterviewConf?.username ?? '';
-    const profileData = legacyInterviewConf?.profileData ?? '';
-    const context = legacyInterviewConf?.jobDescription ?? '';
+  private async migrateLegacyConfig(accountId: string): Promise<'migrated' | 'failed' | 'none'> {
+    const legacy = getLegacyInterviewConf();
+    const fullName = legacy?.username ?? '';
+    const profileData = legacy?.profileData ?? '';
+    const context = legacy?.jobDescription ?? '';
     if (!fullName && !profileData && !context) return 'none';
+
+    this.migrationOwnerId ??= accountId;
+    if (this.migrationOwnerId !== accountId) return 'none';
 
     const result = await this.updateConfig(fullName, profileData, context);
     if (!result.success) {

--- a/src/main/services/account.service.ts
+++ b/src/main/services/account.service.ts
@@ -29,8 +29,11 @@ export class AccountService {
       // Pre-sync builds kept this config on local disk only. If the account has none yet,
       // adopt the leftover local copy instead of presenting the user an empty profile.
       if (!interviewConfig) {
-        const migrated = await this.migrateLegacyConfig();
-        if (migrated) return { success: true };
+        const migration = await this.migrateLegacyConfig();
+        if (migration === 'migrated') return { success: true };
+        if (migration === 'failed') {
+          return { success: false, error: 'Failed to migrate local configuration' };
+        }
       }
 
       appStateService.updateState({
@@ -52,18 +55,30 @@ export class AccountService {
    * Push a pre-sync local config up to the account, once. The local copy is only
    * dropped after the backend confirms the write, so a failed migration is retried
    * on the next launch rather than losing the user's profile.
+   *
+   * 'none' means there was nothing local to migrate, which is distinct from a push
+   * that failed: only the former should leave the user looking at a blank profile.
    */
-  private async migrateLegacyConfig(): Promise<boolean> {
+  private async migrateLegacyConfig(): Promise<'migrated' | 'failed' | 'none'> {
     const fullName = legacyInterviewConf?.username ?? '';
     const profileData = legacyInterviewConf?.profileData ?? '';
     const context = legacyInterviewConf?.jobDescription ?? '';
-    if (!fullName && !profileData && !context) return false;
+    if (!fullName && !profileData && !context) return 'none';
 
     const result = await this.updateConfig(fullName, profileData, context);
-    if (!result.success) return false;
+    if (!result.success) {
+      // Surface the local copy rather than an empty form, but leave it unloaded so the
+      // dialog keeps Save disabled and retries the pull instead of letting the user
+      // overwrite the account from a half-migrated state.
+      appStateService.updateState({
+        interviewConfig: { fullName, profileData, context },
+        interviewConfigLoaded: false,
+      });
+      return 'failed';
+    }
 
     clearLegacyInterviewConf();
-    return true;
+    return 'migrated';
   }
 
   /**
@@ -93,6 +108,18 @@ export class AccountService {
     } catch {
       return { success: false, error: 'Failed to update account' };
     }
+  }
+
+  /**
+   * Drop the signed-out account's config from memory. Nothing else resets it, so
+   * without this the next user on this device inherits the previous user's profile
+   * whenever their post-login pull fails, and can overwrite their own account with it.
+   */
+  clearState(): void {
+    appStateService.updateState({
+      interviewConfig: { fullName: '', profileData: '', context: '' },
+      interviewConfigLoaded: false,
+    });
   }
 }
 

--- a/src/main/services/account.service.ts
+++ b/src/main/services/account.service.ts
@@ -18,16 +18,27 @@ import { appStateService } from './app-state.service.js';
 export class AccountService {
   private client = new UsersApi();
 
-  /**
-   * Bumped by every write to the config in app state.
-   *
-   * The startup pull is deliberately unawaited and can take up to the 30s request timeout, so
-   * it can still be in flight when the user saves from the dialog. Applying its response then
-   * would put the pre-save config back, and nothing shows it: the dialog is already closed, and
-   * the suggestion services read the config straight out of app state, so the rest of the
-   * session runs on the old CV.
-   */
+  /** Bumped by every write to the config in app state. See `applyIfCurrent`. */
   private generation = 0;
+
+  /**
+   * Write a config read into app state, unless something newer landed while it was in flight.
+   *
+   * The startup pull is deliberately unawaited and can take up to the 30s request timeout, so a
+   * save from the dialog, a logout, or a second pull can all land first. Applying the older read
+   * afterwards shows nothing: the dialog is closed by then, and the suggestion services read the
+   * config straight out of app state, so the rest of the session would run on the stale CV.
+   *
+   * Writes the caller already knows to be authoritative (`updateConfig`, `clearState`) bump the
+   * generation directly instead of going through here.
+   */
+  private applyIfCurrent(generation: number, config: InterviewConfig, loaded: boolean): boolean {
+    if (generation !== this.generation) return false;
+
+    this.generation++;
+    appStateService.updateState({ interviewConfig: config, interviewConfigLoaded: loaded });
+    return true;
+  }
 
   /**
    * Pull the authenticated user's persisted interview config from the backend
@@ -48,28 +59,24 @@ export class AccountService {
       // Pre-sync builds kept this config on local disk only. If the account has none yet,
       // adopt the leftover local copy instead of presenting the user an empty profile.
       if (!interviewConfig) {
-        const migration = await this.migrateLegacyConfig(account._id);
+        const migration = await this.migrateLegacyConfig(account._id, generation);
         if (migration === 'migrated') return { success: true };
         if (migration === 'failed') {
           return { success: false, error: 'Failed to migrate local configuration' };
         }
       }
 
-      // A save, a logout or a later pull landed while this request was in flight. Its result is
-      // the newer one, so drop this response rather than reverting to what the account held
-      // when this pull started. Reported as success: the fetch itself worked, and the config
-      // in state is loaded and current.
-      if (generation !== this.generation) return { success: true };
-      this.generation++;
-
-      appStateService.updateState({
-        interviewConfig: {
+      // Success either way: the fetch itself worked, and if this read was superseded then what
+      // is in state is newer than what this response carried.
+      this.applyIfCurrent(
+        generation,
+        {
           fullName: interviewConfig?.full_name ?? '',
           profileData: interviewConfig?.profile_data ?? '',
           context: interviewConfig?.context ?? '',
         },
-        interviewConfigLoaded: true,
-      });
+        true
+      );
       if (interviewConfig) this.discardLegacyConfigIfOwned(account._id);
       return { success: true };
     } catch {
@@ -91,7 +98,10 @@ export class AccountService {
    * user's CV, because a failed push deliberately keeps the copy around for retry. The
    * claim is persisted, since that retry can happen in a later run of the app.
    */
-  private async migrateLegacyConfig(accountId: string): Promise<'migrated' | 'failed' | 'none'> {
+  private async migrateLegacyConfig(
+    accountId: string,
+    generation: number
+  ): Promise<'migrated' | 'failed' | 'none'> {
     const legacy = getLegacyInterviewConf();
     const fullName = legacy?.username ?? '';
     const profileData = legacy?.profileData ?? '';
@@ -109,11 +119,10 @@ export class AccountService {
     if (!result.success) {
       // Surface the local copy rather than an empty form, but leave it unloaded so the
       // dialog keeps Save disabled and retries the pull instead of letting the user
-      // overwrite the account from a half-migrated state.
-      appStateService.updateState({
-        interviewConfig: { fullName, profileData, context },
-        interviewConfigLoaded: false,
-      });
+      // overwrite the account from a half-migrated state. Guarded like any other read: two
+      // pulls can both reach this on first launch after upgrade, and a failed one must not
+      // put Save back behind a lock the successful one just released.
+      this.applyIfCurrent(generation, { fullName, profileData, context }, false);
       return 'failed';
     }
 

--- a/src/main/services/app-state.service.ts
+++ b/src/main/services/app-state.service.ts
@@ -24,6 +24,7 @@ const DEFAULT_STATE: AppState = {
   credits: undefined,
   userRole: undefined,
   providedLLMModel: undefined,
+  interviewConfig: { fullName: '', profileData: '', context: '' },
 };
 
 export class AppStateService {

--- a/src/main/services/app-state.service.ts
+++ b/src/main/services/app-state.service.ts
@@ -7,6 +7,7 @@ import {
   ActionSuggestion,
   AppState,
   LiveSuggestion,
+  RendererAppState,
   RunningState,
   Speaker,
   SuggestionState,
@@ -77,19 +78,40 @@ export class AppStateService {
     return { ...this.state };
   }
 
+  /**
+   * The state as the renderer sees it. Keeps the CV and job description out of IPC: they can
+   * run to hundreds of KB and every state change broadcasts the whole object.
+   */
+  getRendererState(): RendererAppState {
+    const { interviewConfig, ...rest } = this.state;
+    return {
+      ...rest,
+      interviewConfig: {
+        fullName: interviewConfig.fullName,
+        hasProfileData: interviewConfig.profileData.trim() !== '',
+      },
+    };
+  }
+
   updateState(updates: Partial<AppState>): AppState {
+    // The health-check loops re-report identical values every 1-5s. Broadcasting those would
+    // re-render every subscriber for nothing, so only notify when something actually moved.
+    const changed = (Object.keys(updates) as (keyof AppState)[]).some(
+      (key) => !Object.is(this.state[key], updates[key])
+    );
+
     this.state = { ...this.state, ...updates };
-    const s = this.getState();
-    // broadcast update to renderer if window available
-    this.notifyRenderer();
-    return s;
+    if (changed) {
+      this.notifyRenderer();
+    }
+    return this.getState();
   }
 
   private notifyRenderer(): void {
     try {
       const win = getWindowReference();
       if (win && !win.isDestroyed()) {
-        win.webContents.send('app:state-updated', this.getState());
+        win.webContents.send('app:state-updated', this.getRendererState());
       }
     } catch (e) {
       console.warn('Failed to broadcast app state update:', e);

--- a/src/main/services/app-state.service.ts
+++ b/src/main/services/app-state.service.ts
@@ -88,7 +88,11 @@ export class AppStateService {
       ...rest,
       interviewConfig: {
         fullName: interviewConfig.fullName,
-        hasProfileData: interviewConfig.profileData.trim() !== '',
+        // Length first: this runs on every broadcast, and trimming a 128,000-character CV to
+        // learn it is non-empty copies the whole string. The empty case is the only one that
+        // needs the trim at all, to keep whitespace from reading as a set profile.
+        hasProfileData:
+          interviewConfig.profileData.length > 0 && interviewConfig.profileData.trim() !== '',
       },
     };
   }

--- a/src/main/services/app-state.service.ts
+++ b/src/main/services/app-state.service.ts
@@ -25,6 +25,7 @@ const DEFAULT_STATE: AppState = {
   userRole: undefined,
   providedLLMModel: undefined,
   interviewConfig: { fullName: '', profileData: '', context: '' },
+  interviewConfigLoaded: false,
 };
 
 export class AppStateService {

--- a/src/main/services/auth.service.ts
+++ b/src/main/services/auth.service.ts
@@ -1,5 +1,6 @@
 import { AuthApi } from '../api/auth.js';
 import { configStore } from '../store/config.store.js';
+import { accountService } from './account.service.js';
 import { appStateService } from './app-state.service.js';
 import { disableStealth } from './window-control.service.js';
 
@@ -98,6 +99,9 @@ export class AuthService {
 
         // update app state to logged in
         appStateService.updateState({ isLoggedIn: true });
+
+        // pull this account's synced config (full name, profile, context) from the backend
+        await accountService.pullFromBackend();
 
         return { success: true };
       } catch {

--- a/src/main/services/auth.service.ts
+++ b/src/main/services/auth.service.ts
@@ -100,7 +100,10 @@ export class AuthService {
         // update app state to logged in
         appStateService.updateState({ isLoggedIn: true });
 
-        // pull this account's synced config (full name, profile, context) from the backend
+        // pull this account's synced config (full name, profile, context) from the backend.
+        // Cleared first so a failed pull leaves the config unloaded rather than whatever
+        // the previously signed-in account left behind.
+        accountService.clearState();
         await accountService.pullFromBackend();
 
         return { success: true };
@@ -129,6 +132,7 @@ export class AuthService {
       // clear session token and update app state
       configStore.updateConfig({ sessionToken: '' });
       appStateService.updateState({ isLoggedIn: false });
+      accountService.clearState();
 
       // clear credentials if remember me is not checked
       const config = configStore.getConfig();

--- a/src/main/services/auth.service.ts
+++ b/src/main/services/auth.service.ts
@@ -103,8 +103,14 @@ export class AuthService {
         // pull this account's synced config (full name, profile, context) from the backend.
         // Cleared first so a failed pull leaves the config unloaded rather than whatever
         // the previously signed-in account left behind.
+        //
+        // Left unawaited for the same reason HealthCheckService.start() does not await it: the
+        // request carries a full CV and runs to a 30s timeout, and awaiting it here would hold
+        // the login button on a spinner that long whenever the socket stalls. Nothing needs the
+        // config to be loaded before the main screen appears - Start gates on
+        // `interviewConfigLoaded` and retries the pull itself, and the dialog refreshes on open.
         accountService.clearState();
-        await accountService.pullFromBackend();
+        void accountService.pullFromBackend();
 
         return { success: true };
       } catch {

--- a/src/main/services/health-check.service.ts
+++ b/src/main/services/health-check.service.ts
@@ -5,6 +5,7 @@
 
 import { HealthCheckApi } from '../api/health-check.js';
 import { safeSleep } from '../utils/sleep.js';
+import { accountService } from './account.service.js';
 import { appStateService } from './app-state.service.js';
 import { authService } from './auth.service.js';
 import { pushNotificationService } from './push-notification.service.js';
@@ -33,6 +34,12 @@ export class HealthCheckService {
         userRole: res.data?.user_role,
         providedLLMModel: res.data?.provided_llm_model,
       });
+
+      // Remembered sessions log the user in here without going through authService.login(),
+      // so this is where a returning device needs to pull its synced account config.
+      if (res.status === 200) {
+        await accountService.pullFromBackend();
+      }
     } catch (error) {
       console.error('[HealthCheckService] Initial client ping error:', error);
       appStateService.updateState({ isLoggedIn: false });

--- a/src/main/services/health-check.service.ts
+++ b/src/main/services/health-check.service.ts
@@ -26,20 +26,16 @@ export class HealthCheckService {
     this.running = true;
 
     appStateService.updateState({ isLoggedIn: null });
+    let loggedIn = false;
     try {
       const res = await this.client.pingClient();
+      loggedIn = res.status === 200;
       appStateService.updateState({
-        isLoggedIn: res.status === 200,
+        isLoggedIn: loggedIn,
         credits: res.data?.credits,
         userRole: res.data?.user_role,
         providedLLMModel: res.data?.provided_llm_model,
       });
-
-      // Remembered sessions log the user in here without going through authService.login(),
-      // so this is where a returning device needs to pull its synced account config.
-      if (res.status === 200) {
-        await accountService.pullFromBackend();
-      }
     } catch (error) {
       console.error('[HealthCheckService] Initial client ping error:', error);
       appStateService.updateState({ isLoggedIn: false });
@@ -47,6 +43,14 @@ export class HealthCheckService {
 
     this.startBackendLoop();
     this.startClientLoop();
+
+    // Remembered sessions log the user in here without going through authService.login(),
+    // so this is where a returning device needs to pull its synced account config. Kicked
+    // off after the loops and left unawaited on purpose: a slow /users/me must not keep
+    // backend liveness and session-expiry monitoring from ever starting.
+    if (loggedIn) {
+      void accountService.pullFromBackend();
+    }
   }
 
   /**

--- a/src/main/services/payment.service.ts
+++ b/src/main/services/payment.service.ts
@@ -8,35 +8,11 @@ import {
   AvailableCurrency,
   CreatePaymentRequest,
   CreatePaymentResponse,
-  CreditPlan,
   CreditPlanInfo,
   PaymentHistory,
   PaymentStatusResponse,
 } from '../types/payment.js';
 import { appStateService } from './app-state.service.js';
-
-// Default credit plans
-const DEFAULT_CREDIT_PLANS: CreditPlanInfo[] = [
-  {
-    plan: CreditPlan.Starter,
-    credits: 600,
-    priceUsd: 20,
-    description: 'Starter Pack - Perfect for trying out',
-  },
-  {
-    plan: CreditPlan.Pro,
-    credits: 6000,
-    priceUsd: 100,
-    popular: true,
-    description: 'Popular Choice - Best value for regular users',
-  },
-  {
-    plan: CreditPlan.Enterprise,
-    credits: 60000,
-    priceUsd: 500,
-    description: 'Pro Pack - For power users',
-  },
-];
 
 export class PaymentService {
   private api: PaymentApi;
@@ -46,7 +22,10 @@ export class PaymentService {
   }
 
   /**
-   * Get available credit plans
+   * Get available credit plans.
+   *
+   * Pricing is never synthesized locally: a stale hardcoded plan would quote the user one price
+   * and charge another. Failures surface as errors so the UI can say so.
    */
   async getPlans(): Promise<{ success: boolean; data?: CreditPlanInfo[]; error?: string }> {
     try {
@@ -54,27 +33,22 @@ export class PaymentService {
 
       if (response.error) {
         console.error('[PaymentService] Failed to get plans:', response.error);
-        // Return default plans on error
-        return { success: true, data: DEFAULT_CREDIT_PLANS };
+        return { success: false, error: response.error.message || 'Failed to get plans' };
       }
 
       // Map backend plans to frontend format
       const plans: CreditPlanInfo[] =
-        response.data?.map((plan) => {
-          const defaultPlan = DEFAULT_CREDIT_PLANS.find((p) => p.plan === plan.plan);
-          return {
-            plan: plan.plan,
-            credits: plan.credits,
-            priceUsd: plan.price_usd,
-            popular: defaultPlan?.popular,
-            description: defaultPlan?.description,
-          };
-        }) || [];
+        response.data?.map((plan) => ({
+          plan: plan.plan,
+          credits: plan.credits,
+          priceUsd: plan.price_usd,
+          popular: plan.popular,
+        })) || [];
 
       return { success: true, data: plans };
     } catch (error) {
       console.error('[PaymentService] Failed to get plans:', error);
-      return { success: true, data: DEFAULT_CREDIT_PLANS };
+      return { success: false, error: 'Failed to get plans' };
     }
   }
 

--- a/src/main/services/suggestion-action.service.ts
+++ b/src/main/services/suggestion-action.service.ts
@@ -186,11 +186,12 @@ export class ActionSuggestionService {
   private async generateSuggestion(taskId: string, transcripts: Transcript[]): Promise<void> {
     const timestamp = DateTimeUtil.now();
     const conf = configStore.getConfig();
+    const interviewConfig = appStateService.getState().interviewConfig;
 
     const payload: GenerateActionSuggestionRequest = {
       config: conf.llmConf,
-      profile_data: conf.interviewConf.profileData,
-      context: conf.interviewConf.context,
+      profile_data: interviewConfig.profileData,
+      context: interviewConfig.context,
       transcripts: transcripts,
       image_names: [...this.uploadedImageNames],
     };

--- a/src/main/services/suggestion-action.service.ts
+++ b/src/main/services/suggestion-action.service.ts
@@ -190,7 +190,7 @@ export class ActionSuggestionService {
     const payload: GenerateActionSuggestionRequest = {
       config: conf.llmConf,
       profile_data: conf.interviewConf.profileData,
-      context: conf.interviewConf.jobDescription,
+      context: conf.interviewConf.context,
       transcripts: transcripts,
       image_names: [...this.uploadedImageNames],
     };

--- a/src/main/services/suggestion-live.service.ts
+++ b/src/main/services/suggestion-live.service.ts
@@ -56,7 +56,7 @@ class LiveSuggestionService {
       const requestBody: GenerateLiveSuggestionRequest = {
         config: conf.llmConf,
         profile_data: conf.interviewConf.profileData,
-        context: conf.interviewConf.jobDescription,
+        context: conf.interviewConf.context,
         transcripts: transcripts,
       };
 

--- a/src/main/services/suggestion-live.service.ts
+++ b/src/main/services/suggestion-live.service.ts
@@ -53,10 +53,11 @@ class LiveSuggestionService {
 
     try {
       const conf = configStore.getConfig();
+      const interviewConfig = appStateService.getState().interviewConfig;
       const requestBody: GenerateLiveSuggestionRequest = {
         config: conf.llmConf,
-        profile_data: conf.interviewConf.profileData,
-        context: conf.interviewConf.context,
+        profile_data: interviewConfig.profileData,
+        context: interviewConfig.context,
         transcripts: transcripts,
       };
 

--- a/src/main/services/tools.service.ts
+++ b/src/main/services/tools.service.ts
@@ -31,7 +31,7 @@ class ToolsService {
 
   async exportTranscript(): Promise<string | null> {
     // Prepare request data
-    const username = configStore.getConfig().interviewConf.username;
+    const username = configStore.getConfig().interviewConf.fullName;
     const transcripts = appStateService.getState().transcripts;
     const suggestions = appStateService.getState().liveSuggestions;
 

--- a/src/main/services/tools.service.ts
+++ b/src/main/services/tools.service.ts
@@ -31,7 +31,7 @@ class ToolsService {
 
   async exportTranscript(): Promise<string | null> {
     // Prepare request data
-    const username = configStore.getConfig().interviewConf.fullName;
+    const username = appStateService.getState().interviewConfig.fullName;
     const transcripts = appStateService.getState().transcripts;
     const suggestions = appStateService.getState().liveSuggestions;
 

--- a/src/main/store/config.store.ts
+++ b/src/main/store/config.store.ts
@@ -10,11 +10,6 @@ import { LLMConfig } from '../types/llm.js';
 
 // Runtime configuration (matches Config type in frontend)
 export interface RuntimeConfig {
-  interviewConf: {
-    fullName: string;
-    profileData: string;
-    context: string;
-  };
   language: string;
   sessionToken: string;
   rememberMe: boolean;
@@ -32,11 +27,6 @@ export interface RuntimeConfig {
 
 // Default runtime configuration
 const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
-  interviewConf: {
-    fullName: '',
-    profileData: '',
-    context: '',
-  },
   language: 'en',
   sessionToken: '',
   rememberMe: true,
@@ -88,14 +78,6 @@ class ConfigStore {
   updateConfig(updates: Partial<RuntimeConfig>): RuntimeConfig {
     const current = this.getConfig();
     const updated = { ...current, ...updates };
-
-    // Deep merge interview_conf if it's being partially updated
-    if (updates.interviewConf) {
-      updated.interviewConf = {
-        ...current.interviewConf,
-        ...updates.interviewConf,
-      };
-    }
 
     this.store.set('runtime', updated);
     return updated;
@@ -201,27 +183,17 @@ export const configStore = new ConfigStore();
   }
 })(); // migration block
 
-// interviewConf.username/jobDescription were renamed to fullName/context to match
-// the persisted account fields now synced with the backend. Carry over any value
-// already on disk under the old keys so existing installs don't lose their data.
+// interviewConf (full name, profile, context) used to be cached here, but it's now
+// backend-persisted and lives only in-memory (see AccountService/AppStateService).
+// Drop any leftover local copy so it doesn't linger in the store file.
 (() => {
   // eslint-disable-next-line
-  const rawInterviewConf = (configStore as any).store.get('runtime.interviewConf') as
-    | (Partial<RuntimeConfig['interviewConf']> & { username?: string; jobDescription?: string })
+  const raw = (configStore as any).store.get('runtime') as
+    | (Partial<RuntimeConfig> & { interviewConf?: unknown })
     | undefined;
-  if (!rawInterviewConf) return;
-
-  const legacyUsername = rawInterviewConf.username;
-  const legacyJobDescription = rawInterviewConf.jobDescription;
-  const needsFullName = rawInterviewConf.fullName === undefined && legacyUsername !== undefined;
-  const needsContext = rawInterviewConf.context === undefined && legacyJobDescription !== undefined;
-  if (!needsFullName && !needsContext) return;
-
-  configStore.updateConfig({
-    interviewConf: {
-      fullName: needsFullName ? legacyUsername! : (rawInterviewConf.fullName ?? ''),
-      profileData: rawInterviewConf.profileData ?? '',
-      context: needsContext ? legacyJobDescription! : (rawInterviewConf.context ?? ''),
-    },
-  });
-})(); // legacy interviewConf field migration
+  if (raw && 'interviewConf' in raw) {
+    delete raw.interviewConf;
+    // eslint-disable-next-line
+    (configStore as any).store.set('runtime', raw);
+  }
+})(); // drop legacy local interviewConf

--- a/src/main/store/config.store.ts
+++ b/src/main/store/config.store.ts
@@ -11,9 +11,9 @@ import { LLMConfig } from '../types/llm.js';
 // Runtime configuration (matches Config type in frontend)
 export interface RuntimeConfig {
   interviewConf: {
-    username: string;
+    fullName: string;
     profileData: string;
-    jobDescription: string;
+    context: string;
   };
   language: string;
   sessionToken: string;
@@ -33,9 +33,9 @@ export interface RuntimeConfig {
 // Default runtime configuration
 const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   interviewConf: {
-    username: '',
+    fullName: '',
     profileData: '',
-    jobDescription: '',
+    context: '',
   },
   language: 'en',
   sessionToken: '',
@@ -200,3 +200,28 @@ export const configStore = new ConfigStore();
     configStore.updateConfig(migration);
   }
 })(); // migration block
+
+// interviewConf.username/jobDescription were renamed to fullName/context to match
+// the persisted account fields now synced with the backend. Carry over any value
+// already on disk under the old keys so existing installs don't lose their data.
+(() => {
+  // eslint-disable-next-line
+  const rawInterviewConf = (configStore as any).store.get('runtime.interviewConf') as
+    | (Partial<RuntimeConfig['interviewConf']> & { username?: string; jobDescription?: string })
+    | undefined;
+  if (!rawInterviewConf) return;
+
+  const legacyUsername = rawInterviewConf.username;
+  const legacyJobDescription = rawInterviewConf.jobDescription;
+  const needsFullName = rawInterviewConf.fullName === undefined && legacyUsername !== undefined;
+  const needsContext = rawInterviewConf.context === undefined && legacyJobDescription !== undefined;
+  if (!needsFullName && !needsContext) return;
+
+  configStore.updateConfig({
+    interviewConf: {
+      fullName: needsFullName ? legacyUsername! : (rawInterviewConf.fullName ?? ''),
+      profileData: rawInterviewConf.profileData ?? '',
+      context: needsContext ? legacyJobDescription! : (rawInterviewConf.context ?? ''),
+    },
+  });
+})(); // legacy interviewConf field migration

--- a/src/main/store/config.store.ts
+++ b/src/main/store/config.store.ts
@@ -42,6 +42,16 @@ const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   autoScrollTranscript: true,
 };
 
+// interviewConf (full name, profile, context) used to be cached under `runtime`, but it's now
+// backend-persisted and lives only in-memory (see AccountService/AppStateService).
+export interface LegacyInterviewConf {
+  username?: string;
+  profileData?: string;
+  jobDescription?: string;
+}
+
+type StoredRuntime = Partial<RuntimeConfig> & { interviewConf?: LegacyInterviewConf };
+
 interface StoredConfig {
   window?: {
     bounds?: { x: number; y: number; width: number; height: number };
@@ -49,7 +59,10 @@ interface StoredConfig {
     zoomFactor?: number;
     opacityLevel?: number;
   };
-  runtime?: Partial<RuntimeConfig>;
+  runtime?: StoredRuntime;
+
+  /** Account id that claimed the leftover pre-sync config; see AccountService.migrateLegacyConfig. */
+  legacyInterviewConfOwner?: string;
 }
 
 class ConfigStore {
@@ -65,22 +78,54 @@ class ConfigStore {
   }
 
   /**
-   * Get runtime configuration from local store
+   * Get runtime configuration from local store.
+   *
+   * `interviewConf` is stripped: it is a pre-sync leftover awaiting migration, and this object
+   * is handed to the renderer over `config:get`. The CV reaches the renderer only through
+   * `account:get`.
    */
   getConfig(): RuntimeConfig {
-    const config = this.store.get('runtime', DEFAULT_RUNTIME_CONFIG);
-    return { ...DEFAULT_RUNTIME_CONFIG, ...config } as RuntimeConfig;
+    const stored: StoredRuntime = { ...this.store.get('runtime', DEFAULT_RUNTIME_CONFIG) };
+    delete stored.interviewConf;
+    return { ...DEFAULT_RUNTIME_CONFIG, ...stored } as RuntimeConfig;
   }
 
   /**
-   * Update runtime configuration in local store
+   * Update runtime configuration in local store.
+   *
+   * Merges onto the raw stored object rather than `getConfig()`, so a leftover `interviewConf`
+   * survives the write instead of being dropped before AccountService can migrate it.
    */
   updateConfig(updates: Partial<RuntimeConfig>): RuntimeConfig {
-    const current = this.getConfig();
-    const updated = { ...current, ...updates };
+    const stored = this.getStoredRuntime() ?? {};
+    this.store.set('runtime', { ...DEFAULT_RUNTIME_CONFIG, ...stored, ...updates });
+    return this.getConfig();
+  }
 
-    this.store.set('runtime', updated);
-    return updated;
+  /**
+   * Raw stored runtime object, without default backfill.
+   *
+   * Needed by migrations that must distinguish "absent on disk" from "set to the default",
+   * and to reach keys that are no longer part of `RuntimeConfig`.
+   */
+  getStoredRuntime(): StoredRuntime | undefined {
+    return this.store.get('runtime');
+  }
+
+  setStoredRuntime(runtime: StoredRuntime): void {
+    this.store.set('runtime', runtime);
+  }
+
+  getLegacyInterviewConfOwner(): string | undefined {
+    return this.store.get('legacyInterviewConfOwner');
+  }
+
+  setLegacyInterviewConfOwner(accountId: string): void {
+    this.store.set('legacyInterviewConfOwner', accountId);
+  }
+
+  clearLegacyInterviewConfOwner(): void {
+    this.store.delete('legacyInterviewConfOwner');
   }
 
   /**
@@ -165,8 +210,7 @@ export const configStore = new ConfigStore();
 // restart, which is why autoScroll was bouncing back to true.
 (() => {
   // read the raw stored object so we can test for undefined values
-  // eslint-disable-next-line
-  const raw = (configStore as any).store.get('runtime') as Partial<RuntimeConfig> | undefined;
+  const raw = configStore.getStoredRuntime();
   const migration: Partial<RuntimeConfig> = {};
   if (raw?.autoScrollLiveSuggestions === undefined) {
     migration.autoScrollLiveSuggestions = true;
@@ -183,27 +227,29 @@ export const configStore = new ConfigStore();
   }
 })(); // migration block
 
-// interviewConf (full name, profile, context) used to be cached here, but it's now
-// backend-persisted and lives only in-memory (see AccountService/AppStateService).
-export interface LegacyInterviewConf {
-  username?: string;
-  profileData?: string;
-  jobDescription?: string;
-}
-
-type StoredRuntime = Partial<RuntimeConfig> & { interviewConf?: LegacyInterviewConf };
-
 // Read (but do not yet delete) any leftover local copy, so AccountService can migrate it
 // onto the account. Deleting here unconditionally would destroy the only copy whenever the
 // first launch after upgrade happens to be offline.
-let legacyInterviewConf: LegacyInterviewConf | null = (() => {
-  // eslint-disable-next-line
-  const raw = (configStore as any).store.get('runtime') as StoredRuntime | undefined;
-  return raw?.interviewConf ?? null;
-})(); // read legacy local interviewConf
+let legacyInterviewConf: LegacyInterviewConf | null =
+  configStore.getStoredRuntime()?.interviewConf ?? null;
 
 export function getLegacyInterviewConf(): LegacyInterviewConf | null {
   return legacyInterviewConf;
+}
+
+/**
+ * Account id that claimed the leftover pre-sync config.
+ *
+ * Persisted rather than held in memory: a failed migration deliberately keeps the local copy
+ * for retry, and an in-process-only claim is lost on restart. Without this, a second user
+ * signing in first after that restart would inherit the first user's CV.
+ */
+export function getLegacyInterviewConfOwner(): string | null {
+  return configStore.getLegacyInterviewConfOwner() ?? null;
+}
+
+export function claimLegacyInterviewConf(accountId: string): void {
+  configStore.setLegacyInterviewConfOwner(accountId);
 }
 
 // Called once the account is known to hold the config, so it stops lingering on disk.
@@ -211,12 +257,11 @@ export function getLegacyInterviewConf(): LegacyInterviewConf | null {
 // sign-in on the same process migrate one user's CV onto a different account.
 export function clearLegacyInterviewConf(): void {
   legacyInterviewConf = null;
+  configStore.clearLegacyInterviewConfOwner();
 
-  // eslint-disable-next-line
-  const raw = (configStore as any).store.get('runtime') as StoredRuntime | undefined;
+  const raw = configStore.getStoredRuntime();
   if (raw && 'interviewConf' in raw) {
     delete raw.interviewConf;
-    // eslint-disable-next-line
-    (configStore as any).store.set('runtime', raw);
+    configStore.setStoredRuntime(raw);
   }
 }

--- a/src/main/store/config.store.ts
+++ b/src/main/store/config.store.ts
@@ -196,14 +196,22 @@ type StoredRuntime = Partial<RuntimeConfig> & { interviewConf?: LegacyInterviewC
 // Read (but do not yet delete) any leftover local copy, so AccountService can migrate it
 // onto the account. Deleting here unconditionally would destroy the only copy whenever the
 // first launch after upgrade happens to be offline.
-export const legacyInterviewConf: LegacyInterviewConf | null = (() => {
+let legacyInterviewConf: LegacyInterviewConf | null = (() => {
   // eslint-disable-next-line
   const raw = (configStore as any).store.get('runtime') as StoredRuntime | undefined;
   return raw?.interviewConf ?? null;
 })(); // read legacy local interviewConf
 
+export function getLegacyInterviewConf(): LegacyInterviewConf | null {
+  return legacyInterviewConf;
+}
+
 // Called once the account is known to hold the config, so it stops lingering on disk.
+// The in-memory copy goes too: it outlives sign-out, so leaving it would let a later
+// sign-in on the same process migrate one user's CV onto a different account.
 export function clearLegacyInterviewConf(): void {
+  legacyInterviewConf = null;
+
   // eslint-disable-next-line
   const raw = (configStore as any).store.get('runtime') as StoredRuntime | undefined;
   if (raw && 'interviewConf' in raw) {

--- a/src/main/store/config.store.ts
+++ b/src/main/store/config.store.ts
@@ -185,15 +185,30 @@ export const configStore = new ConfigStore();
 
 // interviewConf (full name, profile, context) used to be cached here, but it's now
 // backend-persisted and lives only in-memory (see AccountService/AppStateService).
-// Drop any leftover local copy so it doesn't linger in the store file.
-(() => {
+export interface LegacyInterviewConf {
+  username?: string;
+  profileData?: string;
+  jobDescription?: string;
+}
+
+type StoredRuntime = Partial<RuntimeConfig> & { interviewConf?: LegacyInterviewConf };
+
+// Read (but do not yet delete) any leftover local copy, so AccountService can migrate it
+// onto the account. Deleting here unconditionally would destroy the only copy whenever the
+// first launch after upgrade happens to be offline.
+export const legacyInterviewConf: LegacyInterviewConf | null = (() => {
   // eslint-disable-next-line
-  const raw = (configStore as any).store.get('runtime') as
-    | (Partial<RuntimeConfig> & { interviewConf?: unknown })
-    | undefined;
+  const raw = (configStore as any).store.get('runtime') as StoredRuntime | undefined;
+  return raw?.interviewConf ?? null;
+})(); // read legacy local interviewConf
+
+// Called once the account is known to hold the config, so it stops lingering on disk.
+export function clearLegacyInterviewConf(): void {
+  // eslint-disable-next-line
+  const raw = (configStore as any).store.get('runtime') as StoredRuntime | undefined;
   if (raw && 'interviewConf' in raw) {
     delete raw.interviewConf;
     // eslint-disable-next-line
     (configStore as any).store.set('runtime', raw);
   }
-})(); // drop legacy local interviewConf
+}

--- a/src/main/types/account.ts
+++ b/src/main/types/account.ts
@@ -1,0 +1,27 @@
+/**
+ * Account Types
+ */
+
+export interface InterviewConfig {
+  full_name: string;
+  profile_data: string;
+  context: string;
+}
+
+export interface UserAccount {
+  _id: string;
+  username: string;
+  email: string;
+  role: string;
+  status: string;
+  credits: number;
+  interview_config: InterviewConfig | null;
+  created_at: number;
+  updated_at: number | null;
+}
+
+export interface UpdateInterviewConfigRequest {
+  full_name: string;
+  profile_data: string;
+  context: string;
+}

--- a/src/main/types/app-state.ts
+++ b/src/main/types/app-state.ts
@@ -51,6 +51,12 @@ export interface ActionSuggestion {
   error: string;
 }
 
+export interface InterviewConfig {
+  fullName: string;
+  profileData: string;
+  context: string;
+}
+
 export interface AppState {
   isStealth: boolean;
   isBackendLive: boolean | null;
@@ -62,4 +68,5 @@ export interface AppState {
   credits?: number;
   userRole?: UserRole;
   providedLLMModel?: string;
+  interviewConfig: InterviewConfig;
 }

--- a/src/main/types/app-state.ts
+++ b/src/main/types/app-state.ts
@@ -57,6 +57,18 @@ export interface InterviewConfig {
   context: string;
 }
 
+/**
+ * What the renderer is told about the interview config.
+ *
+ * The profile and context hold a full CV and job description (up to 128k chars each) and the
+ * whole app state is broadcast on every change, so the bulk stays in the main process. The
+ * configuration dialog fetches the full values on demand over `account:get`.
+ */
+export interface InterviewConfigSummary {
+  fullName: string;
+  hasProfileData: boolean;
+}
+
 export interface AppState {
   isStealth: boolean;
   isBackendLive: boolean | null;
@@ -72,3 +84,8 @@ export interface AppState {
   /** False until the account's config has been read this session; editing is unsafe before then. */
   interviewConfigLoaded: boolean;
 }
+
+/** The app state as sent to the renderer, with the interview config reduced to a summary. */
+export type RendererAppState = Omit<AppState, 'interviewConfig'> & {
+  interviewConfig: InterviewConfigSummary;
+};

--- a/src/main/types/app-state.ts
+++ b/src/main/types/app-state.ts
@@ -69,4 +69,6 @@ export interface AppState {
   userRole?: UserRole;
   providedLLMModel?: string;
   interviewConfig: InterviewConfig;
+  /** False until the account's config has been read this session; editing is unsafe before then. */
+  interviewConfigLoaded: boolean;
 }

--- a/src/renderer/components/custom/configuration-dialog.tsx
+++ b/src/renderer/components/custom/configuration-dialog.tsx
@@ -4,7 +4,7 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { useConfigStore } from '@/hooks/use-config-store';
+import { useAppState } from '@/hooks/use-app-state';
 import { getElectron } from '@/lib/utils';
 
 import {
@@ -25,7 +25,7 @@ interface ConfigurationDialogProps {
 }
 
 export default function ConfigurationDialog({ isOpen, onOpenChange }: ConfigurationDialogProps) {
-  const { config, loadConfig } = useConfigStore();
+  const { appState } = useAppState();
 
   const [name, setName] = useState('');
   const [profileData, setProfileData] = useState('');
@@ -38,13 +38,13 @@ export default function ConfigurationDialog({ isOpen, onOpenChange }: Configurat
 
     // Queue state updates in a single microtask to avoid cascading renders
     Promise.resolve().then(() => {
-      if (config?.interviewConf) {
-        setName(config.interviewConf.fullName ?? '');
-        setProfileData(config.interviewConf.profileData ?? '');
-        setContext(config.interviewConf.context ?? '');
+      if (appState?.interviewConfig) {
+        setName(appState.interviewConfig.fullName ?? '');
+        setProfileData(appState.interviewConfig.profileData ?? '');
+        setContext(appState.interviewConfig.context ?? '');
       }
     });
-  }, [isOpen, config?.interviewConf]);
+  }, [isOpen, appState?.interviewConfig]);
 
   const handleSave = async () => {
     setSaving(true);
@@ -59,8 +59,7 @@ export default function ConfigurationDialog({ isOpen, onOpenChange }: Configurat
         throw new Error(result.error || 'Failed to save configuration');
       }
 
-      // Refresh the renderer's cached config from the main-process store
-      await loadConfig();
+      // Account update pushes a fresh app-state broadcast, so no manual refresh needed here
       onOpenChange(false);
     } catch (error) {
       console.error('Failed to save configuration:', error);

--- a/src/renderer/components/custom/configuration-dialog.tsx
+++ b/src/renderer/components/custom/configuration-dialog.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { useConfigStore } from '@/hooks/use-config-store';
+import { getElectron } from '@/lib/utils';
 
 import {
   Dialog,
@@ -14,17 +16,21 @@ import {
   DialogTitle,
 } from '../ui/dialog';
 
+// Kept in sync with the backend's MAX_PROFILE_DATA_LENGTH / MAX_CONTEXT_LENGTH (app/cfg/llm.py)
+const MAX_FIELD_LENGTH = 128_000;
+
 interface ConfigurationDialogProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
 export default function ConfigurationDialog({ isOpen, onOpenChange }: ConfigurationDialogProps) {
-  const { config, updateConfig } = useConfigStore();
+  const { config, loadConfig } = useConfigStore();
 
   const [name, setName] = useState('');
   const [profileData, setProfileData] = useState('');
-  const [jobDescription, setJobDescription] = useState('');
+  const [context, setContext] = useState('');
+  const [saving, setSaving] = useState(false);
 
   // Initialize form values when dialog opens - runs before paint
   useEffect(() => {
@@ -33,24 +39,34 @@ export default function ConfigurationDialog({ isOpen, onOpenChange }: Configurat
     // Queue state updates in a single microtask to avoid cascading renders
     Promise.resolve().then(() => {
       if (config?.interviewConf) {
-        setName(config.interviewConf.username ?? '');
+        setName(config.interviewConf.fullName ?? '');
         setProfileData(config.interviewConf.profileData ?? '');
-        setJobDescription(config.interviewConf.jobDescription ?? '');
+        setContext(config.interviewConf.context ?? '');
       }
     });
   }, [isOpen, config?.interviewConf]);
 
   const handleSave = async () => {
-    const interviewConf = {
-      username: name,
-      profileData: profileData,
-      jobDescription: jobDescription,
-    };
+    setSaving(true);
     try {
-      await updateConfig({ interviewConf: interviewConf });
+      const electron = getElectron();
+      if (!electron?.account) {
+        throw new Error('Electron API not available');
+      }
+
+      const result = await electron.account.update(name, profileData, context);
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to save configuration');
+      }
+
+      // Refresh the renderer's cached config from the main-process store
+      await loadConfig();
       onOpenChange(false);
     } catch (error) {
       console.error('Failed to save configuration:', error);
+      toast.error(error instanceof Error ? error.message : 'Failed to save configuration');
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -89,7 +105,7 @@ export default function ConfigurationDialog({ isOpen, onOpenChange }: Configurat
                 onChange={(e) => setProfileData(e.target.value)}
                 placeholder="Enter your profile information. (e.g. your CV/resume, LinkedIn profile, or a brief bio)"
                 className="text-sm min-h-20 max-h-40 overflow-auto"
-                maxLength={60000}
+                maxLength={MAX_FIELD_LENGTH}
               />
             </div>
 
@@ -98,11 +114,11 @@ export default function ConfigurationDialog({ isOpen, onOpenChange }: Configurat
                 Context (Recommended)
               </label>
               <Textarea
-                value={jobDescription}
-                onChange={(e) => setJobDescription(e.target.value)}
+                value={context}
+                onChange={(e) => setContext(e.target.value)}
                 placeholder="Enter the context you are targeting. (e.g. the job description, role requirements or any other information)"
                 className="text-sm min-h-20 max-h-40 overflow-auto"
-                maxLength={60000}
+                maxLength={MAX_FIELD_LENGTH}
               />
             </div>
           </div>
@@ -117,9 +133,9 @@ export default function ConfigurationDialog({ isOpen, onOpenChange }: Configurat
               size="sm"
               onClick={handleSave}
               className="bg-primary hover:bg-primary/90"
-              disabled={name.trim() === '' || profileData.trim() === ''}
+              disabled={saving || name.trim() === '' || profileData.trim() === ''}
             >
-              Save Changes
+              {saving ? 'Saving...' : 'Save Changes'}
             </Button>
           </div>
         </DialogFooter>

--- a/src/renderer/components/custom/configuration-dialog.tsx
+++ b/src/renderer/components/custom/configuration-dialog.tsx
@@ -27,6 +27,14 @@ interface ConfigurationDialogProps {
 export default function ConfigurationDialog({ isOpen, onOpenChange }: ConfigurationDialogProps) {
   const { appState } = useAppState();
 
+  // Depend on the values, not the object. Main broadcasts the whole app state every few
+  // seconds (backend ping), which hands the renderer a fresh interviewConfig object each
+  // time - keying the effect on that identity re-ran it mid-edit and wiped the form.
+  const storedName = appState?.interviewConfig?.fullName ?? '';
+  const storedProfileData = appState?.interviewConfig?.profileData ?? '';
+  const storedContext = appState?.interviewConfig?.context ?? '';
+  const configLoaded = appState?.interviewConfigLoaded ?? false;
+
   const [name, setName] = useState('');
   const [profileData, setProfileData] = useState('');
   const [context, setContext] = useState('');
@@ -38,13 +46,18 @@ export default function ConfigurationDialog({ isOpen, onOpenChange }: Configurat
 
     // Queue state updates in a single microtask to avoid cascading renders
     Promise.resolve().then(() => {
-      if (appState?.interviewConfig) {
-        setName(appState.interviewConfig.fullName ?? '');
-        setProfileData(appState.interviewConfig.profileData ?? '');
-        setContext(appState.interviewConfig.context ?? '');
-      }
+      setName(storedName);
+      setProfileData(storedProfileData);
+      setContext(storedContext);
     });
-  }, [isOpen, appState?.interviewConfig]);
+  }, [isOpen, storedName, storedProfileData, storedContext]);
+
+  // A save fully replaces the stored config, so retry a failed startup pull before
+  // letting the user edit - otherwise they would overwrite the account with blanks.
+  useEffect(() => {
+    if (!isOpen || configLoaded) return;
+    void getElectron()?.account?.refresh();
+  }, [isOpen, configLoaded]);
 
   const handleSave = async () => {
     setSaving(true);
@@ -125,6 +138,11 @@ export default function ConfigurationDialog({ isOpen, onOpenChange }: Configurat
 
         <DialogFooter>
           <div className="flex items-center justify-end gap-2 w-full">
+            {!configLoaded && (
+              <p className="mr-auto text-xs text-destructive">
+                Could not load your saved configuration. Reconnect before editing.
+              </p>
+            )}
             <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
@@ -132,7 +150,7 @@ export default function ConfigurationDialog({ isOpen, onOpenChange }: Configurat
               size="sm"
               onClick={handleSave}
               className="bg-primary hover:bg-primary/90"
-              disabled={saving || name.trim() === '' || profileData.trim() === ''}
+              disabled={saving || !configLoaded || name.trim() === '' || profileData.trim() === ''}
             >
               {saving ? 'Saving...' : 'Save Changes'}
             </Button>

--- a/src/renderer/components/custom/configuration-dialog.tsx
+++ b/src/renderer/components/custom/configuration-dialog.tsx
@@ -17,6 +17,8 @@ import {
 
 // Kept in sync with the backend's MAX_PROFILE_DATA_LENGTH / MAX_CONTEXT_LENGTH (app/cfg/llm.py)
 const MAX_FIELD_LENGTH = 128_000;
+// Kept in sync with the backend's MAX_USERNAME_LENGTH (app/cfg/llm.py)
+const MAX_NAME_LENGTH = 1_000;
 
 interface ConfigurationDialogProps {
   isOpen: boolean;
@@ -112,7 +114,7 @@ export default function ConfigurationDialog({ isOpen, onOpenChange }: Configurat
                 onChange={(e) => setName(e.target.value)}
                 placeholder="Enter your profile name"
                 className="text-sm"
-                maxLength={100}
+                maxLength={MAX_NAME_LENGTH}
               />
             </div>
 

--- a/src/renderer/components/custom/configuration-dialog.tsx
+++ b/src/renderer/components/custom/configuration-dialog.tsx
@@ -4,7 +4,6 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { useAppState } from '@/hooks/use-app-state';
 import { getElectron } from '@/lib/utils';
 
 import {
@@ -25,39 +24,48 @@ interface ConfigurationDialogProps {
 }
 
 export default function ConfigurationDialog({ isOpen, onOpenChange }: ConfigurationDialogProps) {
-  const { appState } = useAppState();
-
-  // Depend on the values, not the object. Main broadcasts the whole app state every few
-  // seconds (backend ping), which hands the renderer a fresh interviewConfig object each
-  // time - keying the effect on that identity re-ran it mid-edit and wiped the form.
-  const storedName = appState?.interviewConfig?.fullName ?? '';
-  const storedProfileData = appState?.interviewConfig?.profileData ?? '';
-  const storedContext = appState?.interviewConfig?.context ?? '';
-  const configLoaded = appState?.interviewConfigLoaded ?? false;
-
   const [name, setName] = useState('');
   const [profileData, setProfileData] = useState('');
   const [context, setContext] = useState('');
   const [saving, setSaving] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [configLoaded, setConfigLoaded] = useState(false);
 
-  // Initialize form values when dialog opens - runs before paint
+  // Load once per open, straight from main, rather than tracking app state. A save replaces
+  // the whole config, so this both refreshes what another device may have changed and keeps
+  // a late-arriving update from overwriting what the user is currently typing.
   useEffect(() => {
     if (!isOpen) return;
 
-    // Queue state updates in a single microtask to avoid cascading renders
-    Promise.resolve().then(() => {
-      setName(storedName);
-      setProfileData(storedProfileData);
-      setContext(storedContext);
-    });
-  }, [isOpen, storedName, storedProfileData, storedContext]);
+    let cancelled = false;
+    setLoading(true);
+    setConfigLoaded(false);
 
-  // A save fully replaces the stored config, so retry a failed startup pull before
-  // letting the user edit - otherwise they would overwrite the account with blanks.
-  useEffect(() => {
-    if (!isOpen || configLoaded) return;
-    void getElectron()?.account?.refresh();
-  }, [isOpen, configLoaded]);
+    void (async () => {
+      try {
+        const result = await getElectron()?.account?.get();
+        if (cancelled) return;
+
+        // Show whatever main has even when the refresh failed, so the user is not staring at a
+        // blank form - but only mark it loaded (and thus safe to save over) when it succeeded.
+        if (result?.data) {
+          setName(result.data.fullName);
+          setProfileData(result.data.profileData);
+          setContext(result.data.context);
+        }
+        setConfigLoaded(result?.success ?? false);
+      } catch (error) {
+        console.error('Failed to load configuration:', error);
+        if (!cancelled) setConfigLoaded(false);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
 
   const handleSave = async () => {
     setSaving(true);
@@ -138,7 +146,8 @@ export default function ConfigurationDialog({ isOpen, onOpenChange }: Configurat
 
         <DialogFooter>
           <div className="flex items-center justify-end gap-2 w-full">
-            {!configLoaded && (
+            {loading && <p className="mr-auto text-xs text-muted-foreground">Loading...</p>}
+            {!loading && !configLoaded && (
               <p className="mr-auto text-xs text-destructive">
                 Could not load your saved configuration. Reconnect before editing.
               </p>
@@ -150,7 +159,13 @@ export default function ConfigurationDialog({ isOpen, onOpenChange }: Configurat
               size="sm"
               onClick={handleSave}
               className="bg-primary hover:bg-primary/90"
-              disabled={saving || !configLoaded || name.trim() === '' || profileData.trim() === ''}
+              disabled={
+                saving ||
+                loading ||
+                !configLoaded ||
+                name.trim() === '' ||
+                profileData.trim() === ''
+              }
             >
               {saving ? 'Saving...' : 'Save Changes'}
             </Button>

--- a/src/renderer/components/custom/control-panel/index.tsx
+++ b/src/renderer/components/custom/control-panel/index.tsx
@@ -45,7 +45,7 @@ export default function ControlPanel({ onProfileClick, onSignOut }: ControlPanel
   const checkCanStart = () => {
     const checks: { ok: boolean; message: string }[] = [
       { ok: !!config?.interviewConf, message: 'Profile is not set' },
-      { ok: !!config?.interviewConf?.username, message: 'Username is not set' },
+      { ok: !!config?.interviewConf?.fullName, message: 'Full name is not set' },
       { ok: !!config?.interviewConf?.profileData, message: 'Profile data is not set' },
       {
         ok: !audioInputDeviceNotFound,

--- a/src/renderer/components/custom/control-panel/index.tsx
+++ b/src/renderer/components/custom/control-panel/index.tsx
@@ -34,7 +34,7 @@ type StateConfig = {
 export default function ControlPanel({ onProfileClick, onSignOut }: ControlPanelProps) {
   const isStealth = useIsStealthMode();
   const { startAssistant, stopAssistant } = useAssistantService();
-  const { runningState } = useAppState();
+  const { runningState, appState } = useAppState();
   const { config } = useConfigStore();
   const [permGateOpen, setPermGateOpen] = useState(false);
 
@@ -44,9 +44,8 @@ export default function ControlPanel({ onProfileClick, onSignOut }: ControlPanel
 
   const checkCanStart = () => {
     const checks: { ok: boolean; message: string }[] = [
-      { ok: !!config?.interviewConf, message: 'Profile is not set' },
-      { ok: !!config?.interviewConf?.fullName, message: 'Full name is not set' },
-      { ok: !!config?.interviewConf?.profileData, message: 'Profile data is not set' },
+      { ok: !!appState?.interviewConfig?.fullName, message: 'Full name is not set' },
+      { ok: !!appState?.interviewConfig?.profileData, message: 'Profile data is not set' },
       {
         ok: !audioInputDeviceNotFound,
         message: `Audio input device "${config?.audioInputDeviceName}" is not found`,
@@ -132,6 +131,7 @@ export default function ControlPanel({ onProfileClick, onSignOut }: ControlPanel
       <div id="control-panel" className="flex items-center justify-between gap-2 pr-1 pb-0.5">
         <ProfileGroup
           config={config}
+          fullName={appState?.interviewConfig?.fullName}
           onProfileClick={onProfileClick}
           onSignOut={onSignOut}
           getDisabled={getDisabled}

--- a/src/renderer/components/custom/control-panel/index.tsx
+++ b/src/renderer/components/custom/control-panel/index.tsx
@@ -44,6 +44,12 @@ export default function ControlPanel({ onProfileClick, onSignOut }: ControlPanel
 
   const checkCanStart = () => {
     const checks: { ok: boolean; message: string }[] = [
+      // Checked first: an unsynced config reads as empty, and blaming the user for not
+      // setting a name they did set sends them into a dialog that cannot save either.
+      {
+        ok: appState?.interviewConfigLoaded ?? false,
+        message: 'Could not load your saved configuration. Reconnect and try again.',
+      },
       { ok: !!appState?.interviewConfig?.fullName, message: 'Full name is not set' },
       { ok: !!appState?.interviewConfig?.profileData, message: 'Profile data is not set' },
       {

--- a/src/renderer/components/custom/control-panel/index.tsx
+++ b/src/renderer/components/custom/control-panel/index.tsx
@@ -43,24 +43,28 @@ export default function ControlPanel({ onProfileClick, onSignOut }: ControlPanel
   if (isStealth) return null;
 
   const checkCanStart = () => {
-    const checks: { ok: boolean; message: string }[] = [
+    const checks: { ok: boolean; message: string; onFail?: () => void }[] = [
       // Checked first: an unsynced config reads as empty, and blaming the user for not
       // setting a name they did set sends them into a dialog that cannot save either.
       {
         ok: appState?.interviewConfigLoaded ?? false,
-        message: 'Could not load your saved configuration. Reconnect and try again.',
+        message: 'Could not load your saved configuration. Reconnecting - try again in a moment.',
+        // Nothing else re-pulls after a failed startup fetch, so "try again" has to actually
+        // retry: without this the same toast repeats forever however often Start is pressed.
+        onFail: () => void getElectron()?.account?.refresh(),
       },
       { ok: !!appState?.interviewConfig?.fullName, message: 'Full name is not set' },
-      { ok: !!appState?.interviewConfig?.profileData, message: 'Profile data is not set' },
+      { ok: appState?.interviewConfig?.hasProfileData ?? false, message: 'Profile data is not set' },
       {
         ok: !audioInputDeviceNotFound,
         message: `Audio input device "${config?.audioInputDeviceName}" is not found`,
       },
     ];
 
-    for (const { ok, message } of checks) {
+    for (const { ok, message, onFail } of checks) {
       if (!ok) {
         toast.error(message);
+        onFail?.();
         return false;
       }
     }

--- a/src/renderer/components/custom/control-panel/profile-group.tsx
+++ b/src/renderer/components/custom/control-panel/profile-group.tsx
@@ -21,6 +21,7 @@ import { ChangePasswordDialog } from '../change-password-dialog';
 
 interface ProfileGroupProps {
   config?: Config;
+  fullName?: string;
   onProfileClick: () => void;
   onSignOut: () => void;
   getDisabled: (state: RunningState, disableOnRunning?: boolean) => boolean;
@@ -28,6 +29,7 @@ interface ProfileGroupProps {
 
 export function ProfileGroup({
   config,
+  fullName,
   onProfileClick,
   onSignOut,
   getDisabled,
@@ -69,7 +71,7 @@ export function ProfileGroup({
             <div className="max-w-36 overflow-hidden flex items-center gap-2 text-foreground">
               <ChevronUp className="h-4 w-4" />
               <p className="text-sm font-medium truncate">
-                {config?.interviewConf?.fullName || 'Settings'}
+                {fullName || 'Settings'}
               </p>
             </div>
           </Button>

--- a/src/renderer/components/custom/control-panel/profile-group.tsx
+++ b/src/renderer/components/custom/control-panel/profile-group.tsx
@@ -69,7 +69,7 @@ export function ProfileGroup({
             <div className="max-w-36 overflow-hidden flex items-center gap-2 text-foreground">
               <ChevronUp className="h-4 w-4" />
               <p className="text-sm font-medium truncate">
-                {config?.interviewConf?.username || 'Settings'}
+                {config?.interviewConf?.fullName || 'Settings'}
               </p>
             </div>
           </Button>

--- a/src/renderer/components/custom/panels/transcript-panel.tsx
+++ b/src/renderer/components/custom/panels/transcript-panel.tsx
@@ -2,6 +2,7 @@ import { ArrowDown } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { Card } from '@/components/ui/card';
+import { useAppState } from '@/hooks/use-app-state';
 import { useConfigStore } from '@/hooks/use-config-store';
 import useIsStealthMode from '@/hooks/use-is-stealth-mode';
 import { Speaker, type Transcript } from '@/types/transcript';
@@ -17,7 +18,8 @@ interface TranscriptPanelProps {
 
 function TranscriptPanel({ transcripts, style, isRunning = false }: TranscriptPanelProps) {
   const { config, updateConfig } = useConfigStore();
-  const username = config?.interviewConf?.fullName ?? '';
+  const { appState } = useAppState();
+  const username = appState?.interviewConfig?.fullName ?? '';
   const containerRef = useRef<HTMLDivElement>(null);
   const endRef = useRef<HTMLDivElement>(null);
   const [autoScroll, setAutoScroll] = useState<boolean>(() => config?.autoScrollTranscript ?? true);

--- a/src/renderer/components/custom/panels/transcript-panel.tsx
+++ b/src/renderer/components/custom/panels/transcript-panel.tsx
@@ -17,7 +17,7 @@ interface TranscriptPanelProps {
 
 function TranscriptPanel({ transcripts, style, isRunning = false }: TranscriptPanelProps) {
   const { config, updateConfig } = useConfigStore();
-  const username = config?.interviewConf?.username ?? '';
+  const username = config?.interviewConf?.fullName ?? '';
   const containerRef = useRef<HTMLDivElement>(null);
   const endRef = useRef<HTMLDivElement>(null);
   const [autoScroll, setAutoScroll] = useState<boolean>(() => config?.autoScrollTranscript ?? true);

--- a/src/renderer/hooks/use-app-state.tsx
+++ b/src/renderer/hooks/use-app-state.tsx
@@ -41,6 +41,7 @@ class AppStateManager {
       credits: raw.credits,
       userRole: raw.userRole,
       providedLLMModel: raw.providedLLMModel,
+      interviewConfig: raw.interviewConfig ?? { fullName: '', profileData: '', context: '' },
     };
   }
 

--- a/src/renderer/hooks/use-app-state.tsx
+++ b/src/renderer/hooks/use-app-state.tsx
@@ -42,6 +42,7 @@ class AppStateManager {
       userRole: raw.userRole,
       providedLLMModel: raw.providedLLMModel,
       interviewConfig: raw.interviewConfig ?? { fullName: '', profileData: '', context: '' },
+      interviewConfigLoaded: raw.interviewConfigLoaded ?? false,
     };
   }
 

--- a/src/renderer/hooks/use-app-state.tsx
+++ b/src/renderer/hooks/use-app-state.tsx
@@ -41,7 +41,7 @@ class AppStateManager {
       credits: raw.credits,
       userRole: raw.userRole,
       providedLLMModel: raw.providedLLMModel,
-      interviewConfig: raw.interviewConfig ?? { fullName: '', profileData: '', context: '' },
+      interviewConfig: raw.interviewConfig ?? { fullName: '', hasProfileData: false },
       interviewConfigLoaded: raw.interviewConfigLoaded ?? false,
     };
   }

--- a/src/renderer/types/app-state.ts
+++ b/src/renderer/types/app-state.ts
@@ -14,6 +14,12 @@ export enum UserRole {
   Admin = 'admin',
 }
 
+export interface InterviewConfig {
+  fullName: string;
+  profileData: string;
+  context: string;
+}
+
 export interface AppState {
   isLoggedIn: boolean | null;
   isBackendLive: boolean | null;
@@ -24,4 +30,5 @@ export interface AppState {
   credits?: number;
   userRole?: UserRole;
   providedLLMModel?: string;
+  interviewConfig: InterviewConfig;
 }

--- a/src/renderer/types/app-state.ts
+++ b/src/renderer/types/app-state.ts
@@ -31,4 +31,5 @@ export interface AppState {
   userRole?: UserRole;
   providedLLMModel?: string;
   interviewConfig: InterviewConfig;
+  interviewConfigLoaded: boolean;
 }

--- a/src/renderer/types/app-state.ts
+++ b/src/renderer/types/app-state.ts
@@ -14,10 +14,20 @@ export enum UserRole {
   Admin = 'admin',
 }
 
+/** Full config, fetched on demand via `account.get()` - not carried in the app state. */
 export interface InterviewConfig {
   fullName: string;
   profileData: string;
   context: string;
+}
+
+/**
+ * What the app state carries about the interview config. The profile and context can run to
+ * hundreds of KB, so main sends only what the UI renders and the dialog fetches the rest.
+ */
+export interface InterviewConfigSummary {
+  fullName: string;
+  hasProfileData: boolean;
 }
 
 export interface AppState {
@@ -30,6 +40,6 @@ export interface AppState {
   credits?: number;
   userRole?: UserRole;
   providedLLMModel?: string;
-  interviewConfig: InterviewConfig;
+  interviewConfig: InterviewConfigSummary;
   interviewConfigLoaded: boolean;
 }

--- a/src/renderer/types/config.ts
+++ b/src/renderer/types/config.ts
@@ -1,9 +1,9 @@
 import type { LLMConfig } from './llm';
 
 export interface InterviewConf {
-  username: string;
+  fullName: string;
   profileData: string;
-  jobDescription: string;
+  context: string;
 }
 
 export enum Language {

--- a/src/renderer/types/config.ts
+++ b/src/renderer/types/config.ts
@@ -1,17 +1,10 @@
 import type { LLMConfig } from './llm';
 
-export interface InterviewConf {
-  fullName: string;
-  profileData: string;
-  context: string;
-}
-
 export enum Language {
   English = 'en',
 }
 
 export interface Config {
-  interviewConf: InterviewConf;
   language: Language;
 
   // Authentication

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -47,6 +47,15 @@ declare global {
       ) => Promise<{ success: boolean; error?: string }>;
     };
 
+    // Account config management (full name, profile, context) - synced with the backend
+    account: {
+      update: (
+        fullName: string,
+        profileData: string,
+        context: string
+      ) => Promise<{ success: boolean; error?: string }>;
+    };
+
     // Payment management
     payment: {
       getPlans: () => Promise<{ success: boolean; data?: CreditPlanInfo[]; error?: string }>;

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -55,6 +55,11 @@ declare global {
         context: string
       ) => Promise<{ success: boolean; error?: string }>;
       refresh: () => Promise<{ success: boolean; error?: string }>;
+      get: () => Promise<{
+        success: boolean;
+        data: { fullName: string; profileData: string; context: string };
+        error?: string;
+      }>;
     };
 
     // Payment management

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -54,6 +54,7 @@ declare global {
         profileData: string,
         context: string
       ) => Promise<{ success: boolean; error?: string }>;
+      refresh: () => Promise<{ success: boolean; error?: string }>;
     };
 
     // Payment management

--- a/test/account.test.mjs
+++ b/test/account.test.mjs
@@ -1,0 +1,90 @@
+/**
+ * Two silent data-loss paths in the account sync.
+ *
+ * Both only bite when a pull fails or a second account signs in, so nothing surfaces in normal
+ * use: the dialog would enable Save over a copy it failed to refresh (overwriting a newer config
+ * saved on another device), and a pull for one account would delete another account's
+ * not-yet-migrated CV off a shared machine.
+ */
+import { createChecker, loadMain } from './helpers.mjs';
+
+const account = (id, config) => ({
+  data: {
+    _id: id,
+    username: 'jane',
+    email: 'jane@example.com',
+    role: 'user',
+    status: 'active',
+    credits: 0,
+    interview_config: config,
+    created_at: 0,
+    updated_at: null,
+  },
+});
+
+const CONFIG = { full_name: 'Jane', profile_data: 'SERVER CV', context: 'SERVER JD' };
+
+export async function run() {
+  const { check, failures } = createChecker('account.service');
+
+  const store = await loadMain('store/config.store.js');
+  const { accountService } = await loadMain('services/account.service.js');
+  const { appStateService } = await loadMain('services/app-state.service.js');
+  const windowControl = await loadMain('services/window-control.service.js');
+
+  windowControl.setWindowReference({ isDestroyed: () => true, webContents: { send: () => {} } });
+
+  // Stand in for UsersApi. `private` is erased at runtime, so the singleton's client is swappable.
+  let getMe = async () => account('account-A', CONFIG);
+  accountService.client = {
+    getMe: () => getMe(),
+    updateInterviewConfig: async () => ({ error: { code: 'NETWORK_ERROR', message: 'offline' } }),
+  };
+
+  // A good pull first, so the session has a loaded config to go stale.
+  const pulled = await accountService.pullFromBackend();
+  check('pull succeeds', pulled.success === true);
+  check(
+    'pull loads the config',
+    appStateService.getState().interviewConfig.profileData === 'SERVER CV'
+  );
+  check('pull sets the loaded flag', appStateService.getState().interviewConfigLoaded === true);
+
+  // The dialog refresh now fails. The loaded flag deliberately survives (it gates Start), so
+  // reporting success off it alone is what would enable Save over a stale copy.
+  getMe = async () => ({ error: { code: 'NETWORK_ERROR', message: 'offline' } });
+  const editable = await accountService.getEditableConfig();
+  check('stale refresh is not reported as loaded', editable.success === false);
+  check(
+    'stale refresh reports an error',
+    typeof editable.error === 'string' && editable.error !== ''
+  );
+  check('stale refresh still returns values to display', editable.data.profileData === 'SERVER CV');
+  check(
+    'Start is not blocked by a failed dialog refresh',
+    appStateService.getState().interviewConfigLoaded === true
+  );
+
+  // A fresh refresh is safe to save over again.
+  getMe = async () => account('account-A', CONFIG);
+  check(
+    'fresh refresh is reported as loaded',
+    (await accountService.getEditableConfig()).success === true
+  );
+
+  // Ownership: a copy claimed by another account is mid-migration and must outlive this pull.
+  store.claimLegacyInterviewConf('account-A');
+  getMe = async () => account('account-B', CONFIG);
+  await accountService.pullFromBackend();
+  check(
+    "another account's claim survives the pull",
+    store.getLegacyInterviewConfOwner() === 'account-A'
+  );
+
+  // The owning account may discard it: its account now carries the config.
+  getMe = async () => account('account-A', CONFIG);
+  await accountService.pullFromBackend();
+  check('the owning account drops the claim', store.getLegacyInterviewConfOwner() === null);
+
+  return failures;
+}

--- a/test/account.test.mjs
+++ b/test/account.test.mjs
@@ -1,10 +1,11 @@
 /**
- * Two silent data-loss paths in the account sync.
+ * Three silent data-loss paths in the account sync.
  *
- * Both only bite when a pull fails or a second account signs in, so nothing surfaces in normal
- * use: the dialog would enable Save over a copy it failed to refresh (overwriting a newer config
- * saved on another device), and a pull for one account would delete another account's
- * not-yet-migrated CV off a shared machine.
+ * All only bite when a pull fails, stalls, or a second account signs in, so nothing surfaces in
+ * normal use: the dialog would enable Save over a copy it failed to refresh (overwriting a newer
+ * config saved on another device), a pull for one account would delete another account's
+ * not-yet-migrated CV off a shared machine, and a slow startup pull would revert a save made
+ * while it was still in flight.
  */
 import { createChecker, loadMain } from './helpers.mjs';
 
@@ -85,6 +86,36 @@ export async function run() {
   getMe = async () => account('account-A', CONFIG);
   await accountService.pullFromBackend();
   check('the owning account drops the claim', store.getLegacyInterviewConfOwner() === null);
+
+  // HealthCheckService.start() leaves the startup pull unawaited, so it can still be running
+  // when the user saves. Applying its response afterwards would put the pre-save config back
+  // with nothing to show for it: the dialog is closed, and the suggestion services read the
+  // config out of app state, so the rest of the session would run on the old CV.
+  let releasePull;
+  const stalled = new Promise((resolve) => {
+    releasePull = resolve;
+  });
+  getMe = async () => {
+    await stalled;
+    return account('account-A', CONFIG); // what the account held before the save
+  };
+  accountService.client.updateInterviewConfig = async (body) => account('account-A', { ...body });
+
+  const startupPull = accountService.pullFromBackend();
+  await accountService.updateConfig('Jane', 'NEWER CV', 'NEWER JD');
+  check('the save lands', appStateService.getState().interviewConfig.profileData === 'NEWER CV');
+
+  releasePull();
+  const late = await startupPull;
+  check(
+    'a late startup pull does not revert the save',
+    appStateService.getState().interviewConfig.profileData === 'NEWER CV'
+  );
+  check('the superseded pull still reports success', late.success === true);
+  check(
+    'the config stays loaded so Start is not blocked',
+    appStateService.getState().interviewConfigLoaded === true
+  );
 
   return failures;
 }

--- a/test/app-state.test.mjs
+++ b/test/app-state.test.mjs
@@ -1,0 +1,66 @@
+/**
+ * The whole app state is broadcast to the renderer on every change, and the health-check loops
+ * fire every 1-5s. The interview config holds a CV and job description (up to 128k chars each),
+ * so main must send a summary rather than the real thing, and must not broadcast at all when
+ * nothing actually changed.
+ */
+import { createChecker, loadMain } from './helpers.mjs';
+
+export async function run() {
+  const { check, failures } = createChecker('app-state.service');
+
+  const { appStateService } = await loadMain('services/app-state.service.js');
+  const windowControl = await loadMain('services/window-control.service.js');
+
+  const sent = [];
+  windowControl.setWindowReference({
+    isDestroyed: () => false,
+    webContents: { send: (channel, payload) => sent.push({ channel, payload }) },
+  });
+
+  const cv = 'x'.repeat(200_000);
+  const context = 'y'.repeat(150_000);
+  appStateService.updateState({
+    interviewConfig: { fullName: 'Jane', profileData: cv, context },
+    interviewConfigLoaded: true,
+  });
+
+  // Main keeps the real values - the suggestion services read them from here.
+  const state = appStateService.getState();
+  check('main keeps the full CV', state.interviewConfig.profileData.length === cv.length);
+  check('main keeps the full context', state.interviewConfig.context.length === context.length);
+
+  const view = appStateService.getRendererState();
+  check('renderer view exposes fullName', view.interviewConfig.fullName === 'Jane');
+  check('renderer view exposes hasProfileData', view.interviewConfig.hasProfileData === true);
+  check('renderer view drops profileData', !('profileData' in view.interviewConfig));
+  check('renderer view drops context', !('context' in view.interviewConfig));
+  check('renderer view keeps the loaded flag', view.interviewConfigLoaded === true);
+
+  const payload = JSON.stringify(sent.at(-1).payload);
+  check(`broadcast stays small (${payload.length} bytes)`, payload.length < 5_000);
+  check('broadcast carries no CV', !payload.includes('xxxxxxxxxx'));
+
+  // The ping loops re-report identical values; those must not reach the renderer. Prime both
+  // updates first so the loop below carries no new information at all.
+  appStateService.updateState({ isBackendLive: true });
+  appStateService.updateState({ credits: 42, userRole: 'user', providedLLMModel: 'm' });
+  const baseline = sent.length;
+  for (let i = 0; i < 10; i++) {
+    appStateService.updateState({ isBackendLive: true });
+    appStateService.updateState({ credits: 42, userRole: 'user', providedLLMModel: 'm' });
+  }
+  check('identical updates do not broadcast', sent.length === baseline);
+
+  appStateService.updateState({ isBackendLive: false });
+  check('a real change still broadcasts', sent.length === baseline + 1);
+  check('the change is applied', appStateService.getState().isBackendLive === false);
+
+  appStateService.updateState({ interviewConfig: { fullName: 'Jane', profileData: '   ', context: '' } });
+  check(
+    'whitespace-only profile is not reported as set',
+    appStateService.getRendererState().interviewConfig.hasProfileData === false
+  );
+
+  return failures;
+}

--- a/test/config-store.test.mjs
+++ b/test/config-store.test.mjs
@@ -1,0 +1,60 @@
+/**
+ * Interview config was moved off local disk to the backend account. Two invariants matter and
+ * both fail silently: a leftover pre-sync config must survive ordinary config writes until it
+ * has been migrated (otherwise upgrading users lose their CV), and it must never ride along to
+ * the renderer in `config:get`.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { createChecker, loadMain } from './helpers.mjs';
+
+export async function run(userDataDir) {
+  const { check, failures } = createChecker('config.store');
+  const configFile = path.join(userDataDir, 'config.json');
+
+  // Seed the file exactly as a pre-sync install would have left it.
+  fs.writeFileSync(
+    configFile,
+    JSON.stringify({
+      runtime: {
+        language: 'en',
+        email: 'a@b.c',
+        autoScrollTranscript: false,
+        interviewConf: { username: 'Jane', profileData: 'MY CV', jobDescription: 'MY JD' },
+      },
+    })
+  );
+
+  const store = await loadMain('store/config.store.js');
+
+  check('legacy conf is readable for migration', store.getLegacyInterviewConf()?.profileData === 'MY CV');
+
+  const cfg = store.configStore.getConfig();
+  check('getConfig omits interviewConf', !('interviewConf' in cfg));
+  check('getConfig keeps real settings', cfg.email === 'a@b.c' && cfg.autoScrollTranscript === false);
+
+  // The data-loss trap: an unrelated write must not drop the not-yet-migrated copy.
+  store.configStore.updateConfig({ sessionToken: 'tok' });
+  const afterWrite = store.configStore.getStoredRuntime();
+  check('interviewConf survives updateConfig', afterWrite?.interviewConf?.profileData === 'MY CV');
+  check('updateConfig applied the change', afterWrite?.sessionToken === 'tok');
+  check('updateConfig preserved untouched keys', afterWrite?.autoScrollTranscript === false);
+
+  // The claim must outlive a restart, or a second user signing in first inherits the CV.
+  check('no owner before claim', store.getLegacyInterviewConfOwner() === null);
+  store.claimLegacyInterviewConf('account-A');
+  check('owner claim readable', store.getLegacyInterviewConfOwner() === 'account-A');
+  check(
+    'owner claim persisted to disk',
+    JSON.parse(fs.readFileSync(configFile, 'utf8')).legacyInterviewConfOwner === 'account-A'
+  );
+
+  store.clearLegacyInterviewConf();
+  check('clear drops the in-memory copy', store.getLegacyInterviewConf() === null);
+  check('clear drops the disk copy', !('interviewConf' in (store.configStore.getStoredRuntime() ?? {})));
+  check('clear drops the owner claim', store.getLegacyInterviewConfOwner() === null);
+  check('clear leaves other settings intact', store.configStore.getConfig().email === 'a@b.c');
+
+  return failures;
+}

--- a/test/helpers.mjs
+++ b/test/helpers.mjs
@@ -1,0 +1,65 @@
+/**
+ * Test helpers for exercising main-process modules outside Electron.
+ *
+ * The modules under test import `electron`, which only resolves inside an Electron process, so
+ * `stubElectron()` installs a module hook that serves a minimal stand-in. Call it before the
+ * first `loadMain()`. Plain Node, no test framework - see test/run.mjs.
+ */
+import { registerHooks } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const DIST = path.resolve(fileURLToPath(new URL('../electron-dist', import.meta.url)));
+
+/** Serves a fake `electron` whose userData path points at a throwaway directory. */
+export function stubElectron() {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'pia-test-'));
+
+  registerHooks({
+    resolve(specifier, context, next) {
+      if (specifier === 'electron') return { url: 'stub:electron', shortCircuit: true };
+      return next(specifier, context);
+    },
+    load(url, context, next) {
+      if (url !== 'stub:electron') return next(url, context);
+      return {
+        format: 'module',
+        shortCircuit: true,
+        source: `
+const app = {
+  getPath: () => ${JSON.stringify(userData)},
+  getName: () => 'pia-test',
+  getVersion: () => '0.0.0',
+  on: () => {},
+  whenReady: () => Promise.resolve(),
+};
+const ipcMain = { on: () => {}, handle: () => {} };
+const screen = { getPrimaryDisplay: () => ({ workAreaSize: { width: 1920, height: 1080 } }), getAllDisplays: () => [] };
+const shell = { openPath: async () => '' };
+export { app, ipcMain, screen, shell };
+export default { app, ipcMain, screen, shell };`,
+      };
+    },
+  });
+
+  return userData;
+}
+
+/** Import a compiled main-process module by its path under electron-dist/. */
+export function loadMain(relativePath) {
+  return import(pathToFileURL(path.join(DIST, relativePath)).href);
+}
+
+export function createChecker(name) {
+  const failures = [];
+  console.log(`\n# ${name}`);
+  return {
+    check(label, condition) {
+      console.log(`${condition ? '  ok  ' : '  FAIL'} ${label}`);
+      if (!condition) failures.push(`${name}: ${label}`);
+    },
+    failures,
+  };
+}

--- a/test/run.mjs
+++ b/test/run.mjs
@@ -13,7 +13,7 @@ import { stubElectron } from './helpers.mjs';
 const userDataDir = stubElectron();
 
 const failures = [];
-for (const module of ['./config-store.test.mjs', './app-state.test.mjs']) {
+for (const module of ['./config-store.test.mjs', './app-state.test.mjs', './account.test.mjs']) {
   const { run } = await import(module);
   failures.push(...(await run(userDataDir)));
 }

--- a/test/run.mjs
+++ b/test/run.mjs
@@ -1,0 +1,29 @@
+/**
+ * Main-process checks. Run with `pnpm test:main` (builds electron-dist first).
+ *
+ * Deliberately dependency-free: these cover a couple of invariants that fail silently in
+ * production (losing a not-yet-migrated CV, shipping one over IPC on a timer) and are not worth
+ * pulling a test framework in for. Requires Node >= 22.15 for `module.registerHooks`.
+ */
+import fs from 'node:fs';
+
+import { stubElectron } from './helpers.mjs';
+
+// Must run before any module under test is imported.
+const userDataDir = stubElectron();
+
+const failures = [];
+for (const module of ['./config-store.test.mjs', './app-state.test.mjs']) {
+  const { run } = await import(module);
+  failures.push(...(await run(userDataDir)));
+}
+
+fs.rmSync(userDataDir, { recursive: true, force: true });
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} check(s) failed:`);
+  for (const failure of failures) console.error(`  - ${failure}`);
+  process.exit(1);
+}
+
+console.log('\nAll checks passed.');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }],
   "compilerOptions": {
     "paths": {
-      "@/*": ["./renderer/*"]
+      "@/*": ["./src/renderer/*"]
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "files": [],
   "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }],
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./renderer/*"]
     }


### PR DESCRIPTION
## Summary

Syncs the interview configuration (full name, profile/CV, context) with the user's backend account so it follows them across devices.

Backend PR: PowerInterviewAI/backend#34

- Renames `interviewConf.username` / `jobDescription` -> `fullName` / `context` to match the backend's account fields
- Adds `account.service.ts` + IPC wiring to pull the account's config on login and on a remembered session, and to push edits from the configuration dialog
- Drops the local electron-store copy - the backend is now the durable store. Any pre-sync copy on disk is migrated onto the account on the first pull that finds an empty config, and deleted only once the backend confirms the write, so a failed migration retries on the next launch instead of losing the user's CV
- Aligns the dialog's input cap with the backend's real 128k limit (was hardcoded to 60k)

## Data-safety and leakage fixes

- **Blank overwrite.** A save fully replaces the stored config, so a failed startup pull would let the user overwrite their account with blanks. The config now tracks whether it loaded, Save is blocked until it has, and Start says so rather than blaming the user for a name they did set. Start also retries the pull, since nothing else does.
- **Cross-account leakage.** The pre-sync copy is claimed by the first account offered it, and the claim is persisted - a failed migration followed by a restart can no longer push one user's CV onto the next account signed in on a shared machine. Login and logout clear the previous account's config, so a failed pull cannot leave one user looking at another's profile.
- **Stalled startup.** `HealthCheckService.start()` no longer awaits the account pull before starting the liveness and 401 loops, and `ApiClient.request()` takes an opt-in timeout (30s for `UsersApi`) so a stalled socket cannot leave them permanently unstarted.

## Keeping the CV off the wire

The whole app state is broadcast to the renderer on every change, and the health-check loops fire every 1-5s. Holding the config in `AppState` therefore put a full CV and job description (up to 128k chars each) on the wire several times a second.

- Main broadcasts a `{ fullName, hasProfileData }` summary; the dialog fetches the real values on demand over a new `account:get`
- `updateState` skips the broadcast entirely when nothing actually changed
- `config:get` no longer hands the not-yet-migrated copy to the renderer, while `updateConfig` still preserves it on disk until it has been migrated

Measured: **790 bytes per broadcast instead of ~350 KB, and none at all while idle.**

Loading on open rather than tracking app state also fixes two things: a late-arriving pull can no longer reset the form mid-edit, and the refresh it performs first stops a save from silently discarding a change made on another device.

## Deploy order

**The backend must be deployed first.** Against an older backend `/api/users/me` 404s, the config never loads, and starting an interview is blocked for everyone who auto-updates.

## Test plan

- [x] `tsc -p tsconfig.electron.json --noEmit` and `tsc -b tsconfig.json` clean
- [x] `eslint .` clean
- [x] `vite build` and `pnpm electron:build-main` succeed
- [x] `pnpm test:main` - 26 checks covering the two invariants that fail silently: dropping a pre-sync CV before it has been migrated, and putting one back into the app-state broadcast
- [ ] Manual: log in on two devices/accounts, confirm profile/context saved on one shows up on the other
- [ ] Manual: upgrade from a pre-sync build holding a local CV and confirm it migrates onto the account
- [ ] Manual: sign out and sign in as a second account, confirm the first account's profile does not appear

## Known limitation

`PATCH /me/interview-config` replaces the whole config with no version or etag. Refreshing when the dialog opens narrows the window considerably, but two devices editing concurrently is still last-write-wins.
