### PR TITLE
feat(panels): show newest suggestion first

### DIFF
--- a/src/renderer/components/custom/panels/action-suggestions-panel.tsx
+++ b/src/renderer/components/custom/panels/action-suggestions-panel.tsx
@@ -1,5 +1,5 @@
-import { ArrowDown, ImageUp, Loader2, PauseCircle, Zap } from 'lucide-react';
-import React, { useEffect, useRef, useState } from 'react';
+import { ArrowUp, ImageUp, Loader2, PauseCircle, Zap } from 'lucide-react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import { Card } from '@/components/ui/card';
 import { useConfigStore } from '@/hooks/use-config-store';
@@ -31,8 +31,10 @@ function ActionSuggestionsPanel({
 }: ActionSuggestionsPanelProps) {
   const hasItems = actionSuggestions.length > 0;
 
+  // newest first: the incoming array is chronological, the panel renders it reversed
+  const orderedSuggestions = useMemo(() => [...actionSuggestions].reverse(), [actionSuggestions]);
+
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const lastItemRef = useRef<HTMLDivElement | null>(null);
 
   const { config, updateConfig } = useConfigStore();
 
@@ -61,11 +63,11 @@ function ActionSuggestionsPanel({
     actionSuggestions.length > 0 ? actionSuggestions[actionSuggestions.length - 1].answer : ''
   );
 
-  // scroll the final list item into view at the bottom of the container
+  // the newest suggestion sits at the top of the list
   const scrollToLatest = (behavior: ScrollBehavior = 'smooth') => {
-    const last = lastItemRef.current;
-    if (!last) return;
-    last.scrollIntoView({ behavior, block: 'end', inline: 'nearest' });
+    const container = containerRef.current;
+    if (!container) return;
+    container.scrollTo({ top: 0, behavior });
   };
 
   useEffect(() => {
@@ -113,7 +115,7 @@ function ActionSuggestionsPanel({
 
         // choose scroll behavior based on direction
         if (direction === 'end') {
-          // jump to bottom where the most recent element lives
+          // jump to top where the most recent element lives
           scrollToLatest('smooth');
           return;
         }
@@ -187,13 +189,12 @@ function ActionSuggestionsPanel({
 
         {hasItems && (
           <div className="px-2 pt-1 pb-2 space-y-3">
-            {actionSuggestions.map((s, idx) => (
+            {orderedSuggestions.map((s, idx) => (
               <div
-                key={idx}
-                ref={idx === actionSuggestions.length - 1 ? lastItemRef : null}
+                key={orderedSuggestions.length - 1 - idx}
                 className="flex gap-3 pb-3 border-b border-border/40 last:border-0"
               >
-                {idx === actionSuggestions.length - 1 &&
+                {idx === 0 &&
                 (s.state === SuggestionState.Pending || s.state === SuggestionState.Loading) ? (
                   <Loader2 className="h-4 w-4 mt-px text-accent shrink-0 animate-spin" />
                 ) : s.state === SuggestionState.Stopped ? (
@@ -268,9 +269,9 @@ function ActionSuggestionsPanel({
           size="icon-sm"
           className="absolute bottom-3 right-3 rounded-full shadow-md bg-blue-600 text-white hover:bg-blue-600/90"
           onClick={() => scrollToLatest('smooth')}
-          aria-label="Scroll to bottom"
+          aria-label="Scroll to top"
         >
-          <ArrowDown className="size-4" />
+          <ArrowUp className="size-4" />
         </Button>
       )}
     </Card>

--- a/src/renderer/components/custom/panels/live-suggestions-panel.tsx
+++ b/src/renderer/components/custom/panels/live-suggestions-panel.tsx
@@ -1,5 +1,5 @@
-import { ArrowDown, Loader2, PauseCircle, Zap } from 'lucide-react';
-import React, { useEffect, useRef, useState } from 'react';
+import { ArrowUp, Loader2, PauseCircle, Zap } from 'lucide-react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import { useConfigStore } from '@/hooks/use-config-store';
 
@@ -31,8 +31,10 @@ function LiveSuggestionsPanel({
 }: LiveSuggestionsPanelProps) {
   const hasItems = suggestions.length > 0;
 
+  // newest first: the incoming array is chronological, the panel renders it reversed
+  const orderedSuggestions = useMemo(() => [...suggestions].reverse(), [suggestions]);
+
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const lastItemRef = useRef<HTMLDivElement | null>(null);
 
   const { config, updateConfig } = useConfigStore();
 
@@ -59,11 +61,11 @@ function LiveSuggestionsPanel({
     suggestions.length > 0 ? suggestions[suggestions.length - 1].answer : ''
   );
 
-  // helper: scroll last item into view at the bottom of container (conventional for newest)
+  // the newest suggestion sits at the top of the list
   const scrollToLatest = (behavior: ScrollBehavior = 'smooth') => {
-    const last = lastItemRef.current;
-    if (!last) return;
-    last.scrollIntoView({ behavior, block: 'start', inline: 'nearest' });
+    const container = containerRef.current;
+    if (!container) return;
+    container.scrollTo({ top: 0, behavior });
   };
 
   // auto-scroll when suggestions change
@@ -111,7 +113,7 @@ function LiveSuggestionsPanel({
         if (!container) return;
 
         if (direction === 'end') {
-          // scroll to bottom where latest suggestion lives
+          // scroll to top where latest suggestion lives
           scrollToLatest('smooth');
           return;
         }
@@ -185,13 +187,12 @@ function LiveSuggestionsPanel({
 
         {hasItems && (
           <div className="px-2 pt-1 pb-2 space-y-3">
-            {suggestions.map((s, idx) => (
+            {orderedSuggestions.map((s, idx) => (
               <div
-                key={idx}
-                ref={idx === suggestions.length - 1 ? lastItemRef : null}
+                key={orderedSuggestions.length - 1 - idx}
                 className="flex gap-3 pb-3 border-b border-border/40 last:border-0"
               >
-                {idx === suggestions.length - 1 &&
+                {idx === 0 &&
                 (s.state === SuggestionState.Pending || s.state === SuggestionState.Loading) ? (
                   <Loader2 className="h-4 w-4 mt-px text-accent shrink-0 animate-spin" />
                 ) : s.state === SuggestionState.Stopped ? (
@@ -239,9 +240,9 @@ function LiveSuggestionsPanel({
           size="icon-sm"
           className="absolute bottom-3 right-3 rounded-full shadow-md bg-blue-600 text-white hover:bg-blue-600/90"
           onClick={() => scrollToLatest('smooth')}
-          aria-label="Scroll to bottom"
+          aria-label="Scroll to top"
         >
-          <ArrowDown className="size-4" />
+          <ArrowUp className="size-4" />
         </Button>
       )}
     </Card>


### PR DESCRIPTION
Closes #71

## What

Flips both suggestion panels from FIFO to LIFO. The newest suggestion now renders at the top of the live and triggered panels, so the answer the user needs mid-interview is always in the default viewport position instead of drifting off the bottom as the session grows.

## How

The app-state arrays stay chronological. `suggestion-live.service` builds its list from a `Map` in insertion order, `suggestion-action.service` appends, and `tools.service` reads the tail - reversing the source would have rippled into all of them. So each panel reverses a copy at render time and leaves the data alone:

```ts
const orderedSuggestions = useMemo(() => [...suggestions].reverse(), [suggestions]);
```

Everything that pointed at the latest item follows it to the top:

- the in-progress spinner and the `Pending`/`Loading` check move from `idx === length - 1` to `idx === 0`
- `scrollToLatest` scrolls the container to `top: 0` rather than pulling the last DOM node into view, so `lastItemRef` is gone
- the `end` hotkey (`Ctrl+Shift+L` for live, `Ctrl+Shift+O` for triggered) still jumps to the newest item, now upward
- the floating jump button is an `ArrowUp` labelled "Scroll to top"

React keys are derived from the original chronological index (`orderedSuggestions.length - 1 - idx`), so a row keeps its identity as newer suggestions are prepended and streaming text is not remounted.

The auto-scroll effect is deliberately untouched - it reads `suggestions[length - 1]`, still the newest item in the chronological array, so its new-item / became-success / streaming-content triggers fire exactly as before.

## Review notes

- `last:border-0` still removes the divider from the visual bottom row, which is now the oldest item - correct either way
- Prepending relies on browser scroll anchoring to hold position for a user reading an older suggestion with auto-scroll off

## Testing

`pnpm lint`, both `tsc` configs, the renderer build, and `pnpm test:main` (60 checks) all pass locally. No renderer test suite covers these panels, and the change has not been exercised in a running app, so a visual pass on streaming into a top-anchored row is worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
