### PR TITLE
fix(window): raise the minimum height for the transcription dock

### DIFF
--- a/src/main/consts.ts
+++ b/src/main/consts.ts
@@ -4,9 +4,16 @@ export const BACKEND_BASE_URL = EnvUtil.isDev()
   ? 'http://localhost:8080'
   : 'https://api.powerinterviewai.com';
 
-// minimum allowed dimensions for window bounds
+// Minimum allowed dimensions for window bounds. 540 was sized when transcription was a fixed
+// 320px left column and cost width, not height. It now docks at the bottom and takes a band out
+// of the same vertical budget as the suggestion panels, so the minimum grows by the dock's own
+// floor plus the gap above it (TRANSCRIPT_DOCK_MIN_HEIGHT 120 + 4, both in renderer/lib/consts).
 export const MIN_WIDTH = 900;
-export const MIN_HEIGHT = 540;
+export const MIN_HEIGHT = 664;
+
+// Bounds a first launch starts with, before the user resizes and we persist their choice.
+export const DEFAULT_WIDTH = 1024;
+export const DEFAULT_HEIGHT = 768;
 
 // Transcript constants
 export const TRANSCRIPT_INTER_TRANSCRIPT_GAP_MS = 5000;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,7 +6,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Import modules
-import { MIN_HEIGHT, MIN_WIDTH } from './consts.js';
+import { DEFAULT_HEIGHT, DEFAULT_WIDTH, MIN_HEIGHT, MIN_WIDTH } from './consts.js';
 import { registerGlobalHotkeys, unregisterHotkeys } from './hotkeys.js';
 import { registerAccountHandlers } from './ipc/account.js';
 import { registerAppStateHandlers } from './ipc/app-state.js';
@@ -90,8 +90,8 @@ if (!gotLock) {
 // -------------------------------------------------------------
 async function createWindow() {
   const savedBounds = configStore.getWindowBounds() || {
-    width: 1024,
-    height: 640,
+    width: DEFAULT_WIDTH,
+    height: DEFAULT_HEIGHT,
   };
 
   // Clamp to minimum so persisted tiny/invalid bounds don't create unusable windows


### PR DESCRIPTION
Closes #73

## What

Raises `MIN_HEIGHT` from 540 to 664 so the minimum window size accounts for the transcription dock.

## Why 664

540 was set when transcription was a fixed 320px **left column**. It cost width - which is what `MIN_WIDTH = 900` pays for - and the height budget only had to cover the suggestion panels plus the control panel. `9da220b` moved transcription to a full-width bottom dock, so it now takes a band out of the same vertical budget.

The minimum therefore grows by exactly what the dock took: `TRANSCRIPT_DOCK_MIN_HEIGHT` (120) plus the 4px gap above it. `540 + 124 = 664`. The delta argument means the suggestion row keeps precisely the room it had before the dock existed, without depending on any estimate of the titlebar or control-panel heights.

At the new minimum the layout resolves to roughly a 174px dock and a ~400px suggestion row - that is the 30% `TRANSCRIPT_DOCK_RATIO`, not the 120px floor, so the dock still has slack to shrink before anything is clamped.

## Also here

`createWindow` used a hardcoded `1024x640` for a first launch. That is *below* the corrected minimum, so it would have been silently clamped up to 664 and the shipped default would have become an accident of the clamp rather than a deliberate choice. Extracted as `DEFAULT_WIDTH` / `DEFAULT_HEIGHT` and set to 1024x768, which keeps the same proportional headroom over the minimum that 640 had over 540.

## Out of scope

`MIN_WIDTH` is left at 900. It is arguably generous now that the 320px column is gone, but narrowing it is a separate judgment call about how tight the side-by-side suggestion panels can get.

## Testing

`pnpm lint` and `pnpm test:main` (60 checks) pass locally. No test pins the window constants. The change has not been exercised by dragging a real window down to the minimum, so a manual resize check is worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
