### PR TITLE
fix(app-state): actually send the coalesced broadcast

### DIFF
--- a/src/main/services/app-state.service.ts
+++ b/src/main/services/app-state.service.ts
@@ -127,7 +127,7 @@ export class AppStateService {
 
     this.broadcastTimer = setTimeout(() => {
       this.broadcastTimer = null;
-      this.flushRenderer();
+      this.sendToRenderer();
     }, BROADCAST_COALESCE_MS);
   }
 
@@ -143,7 +143,17 @@ export class AppStateService {
 
     clearTimeout(this.broadcastTimer);
     this.broadcastTimer = null;
+    this.sendToRenderer();
+  }
 
+  /**
+   * The actual send. Separate from flushRenderer because the two callers disagree about the
+   * pending check: flushRenderer needs it, the timer callback must not have it. Folding the
+   * send into flushRenderer meant the timer cleared its own handle and then called a method
+   * guarded on that handle, so the coalesced path - the only one production uses - silently
+   * sent nothing at all.
+   */
+  private sendToRenderer(): void {
     try {
       const win = getWindowReference();
       if (win && !win.isDestroyed()) {

--- a/test/app-state.test.mjs
+++ b/test/app-state.test.mjs
@@ -7,6 +7,11 @@
  * streamed token and every ASR partial, and each one clones a transcript array that grows for
  * the whole interview. So these checks flush explicitly rather than counting one send per
  * mutation. The two invariants above are unaffected and are what this file pins.
+ *
+ * Flushing explicitly is also the one path production never takes, so the coalesced path gets
+ * its own check below. Every check here used to flush synchronously while the timer was still
+ * pending - the single arrangement in which the send worked - and that blind spot let a release
+ * ship in which the renderer received no state update at all, ever.
  */
 import { createChecker, loadMain } from './helpers.mjs';
 
@@ -64,6 +69,14 @@ export async function run() {
   appStateService.flushRenderer();
   check('a real change still broadcasts', sent.length === baseline + 1);
   check('the change is applied', appStateService.getState().isBackendLive === false);
+
+  // Nothing in src/ ever calls flushRenderer - the app relies entirely on the timer firing on
+  // its own. So let it, with no flush at all, and check the send actually lands.
+  const beforeCoalesced = sent.length;
+  appStateService.updateState({ isBackendLive: true });
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  check('a coalesced broadcast reaches the renderer', sent.length === beforeCoalesced + 1);
+  check('the coalesced broadcast carries the change', sent.at(-1).payload.isBackendLive === true);
 
   appStateService.updateState({ interviewConfig: { fullName: 'Jane', profileData: '   ', context: '' } });
   check(


### PR DESCRIPTION
Closes #81.

The main process never delivered a single `app:state-updated` push to the renderer, so the renderer ran forever on the one snapshot it took when the first component mounted. Reported as "the Start button does nothing"; a fresh login was equally dead.

## Root cause

```ts
this.broadcastTimer = setTimeout(() => {
  this.broadcastTimer = null;   // handle cleared here...
  this.flushRenderer();         // ...so flushRenderer's own guard trips
}, BROADCAST_COALESCE_MS);
```

`flushRenderer()` opens with `if (!this.broadcastTimer) return;` and holds the only `webContents.send('app:state-updated', ...)` in `src/main/`. Nothing outside `test/` calls it. So every real broadcast went through the timer path, and the timer path sent nothing.

The renderer never recovers because `use-app-state.tsx` starts its polling fallback *only* when `onAppStateUpdated` is absent. It is present, so the renderer subscribed to a channel that never fired and never polled.

## Change

Extract the send into `private sendToRenderer()`. The timer callback calls it directly; `flushRenderer()` keeps its pending check - which is its documented contract, and what the `identical updates do not broadcast` check relies on - then calls it. No signature or semantic change to `flushRenderer()`.

## Test

Every existing check in `test/app-state.test.mjs` calls `flushRenderer()` synchronously while the timer is still pending. That is the one arrangement in which the send worked, which is exactly why this shipped green. Added a check that lets the timer fire on its own with no flush at all.

Verified red before the fix and green after (rebuilding `electron-dist/` in between - `node test/run.mjs` alone runs stale output):

```
  FAIL a coalesced broadcast reaches the renderer
  FAIL the coalesced broadcast carries the change
```

`pnpm test:main`, `pnpm lint`, and `pnpm build` all pass on the branch.

## What this unblocks

Every consumer of the push channel, not just Start: fresh login navigation, the `isLoggedIn: null` startup window that could pin MainPage on "Authenticating…" forever, Idle -> Starting -> Running button transitions and `TransitionOverlay`, live transcripts and both suggestion panels (stuck on placeholder content for a whole interview), credits / user role / backend-live indicators, and the Clear reset from 3a7b660 whose broadcast could not send.

## Also audited

Same class of defect across the client, all clear: every `ipcMain` channel has a matching preload binding and vice versa; all push channels main sends have live preload listeners; the timers in `action-lock.service.ts` and the stall timers in both suggestion services are correct - none repeats the clear-then-call-a-guarded-method shape.

Two pre-existing items noted in #81 as out of scope: the `audioInputDeviceNotFound` use-before-declaration in `control-panel/index.tsx`, and `enumerateDevices()` returning blank labels before mic permission is granted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
