### PR TITLE
feat: 28-language interview picker and mid-interview audio switching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,9 +116,9 @@ triggered it, one write per frame.
 
 ### Interview language
 
-One setting decides three things: which speech model transcribes the call, what language suggestions come back in, and the language of the exported report. `Language` is mirrored across the processes the way `SuggestionMode` is - [src/main/types/language.ts](src/main/types/language.ts) for the request bodies, [src/renderer/types/language.ts](src/renderer/types/language.ts) for the same enum plus the display metadata the picker needs. 28 languages, which is what the backend's Deepgram Nova-3 provider streams: offering one the ASR cannot hear would not degrade, it would answer a question that was never asked. It was six while the backend was AssemblyAI-only.
+One setting decides three things: which speech model transcribes the call, what language suggestions come back in, and the language of the exported report. `Language` is mirrored across the processes the way `SuggestionMode` is - [src/main/types/language.ts](src/main/types/language.ts) for the request bodies, [src/renderer/types/language.ts](src/renderer/types/language.ts) for the same enum plus the display metadata the picker needs. 28 languages, which is exactly what the backend's Deepgram Nova-3 ASR streams: offering one the ASR cannot hear would not degrade, it would answer a question that was never asked.
 
-A backend still configured for AssemblyAI resolves a language it cannot hear back to English rather than faking it, so a client ahead of its backend degrades one session instead of breaking it. `test/language.test.mjs` pins the two mirrors staying in step, which is the failure the widening made likely: an enum member with no picker entry renders a blank trigger, and a picker entry with no enum member resolves straight back to English when picked. The menu is capped and scrolls, because it opens upward from the bottom-most control into an overflow-hidden `main` - an uncapped 28-item list runs off the top of the window rather than flipping.
+A code this build knows but an older backend does not is resolved back to English there rather than faked, so a client ahead of its backend degrades one session instead of breaking it. `test/language.test.mjs` pins the two mirrors staying in step, which is the failure the widening made likely: an enum member with no picker entry renders a blank trigger, and a picker entry with no enum member resolves straight back to English when picked. The menu is capped and scrolls, because it opens upward from the bottom-most control into an overflow-hidden `main` - an uncapped 28-item list runs off the top of the window rather than flipping.
 
 **English is the absence of the feature.** `buildStreamingUrl` sends no `language` parameter at all for English rather than `language=en`, and the backend defaults the request field, so a session that never touches the picker produces exactly the traffic it produced before this existed.
 
@@ -164,6 +164,15 @@ the device with its indicator light on, since nothing else keeps a reference to 
 at construction and `convertTo16kPcm` reads it, so a fresh context would resample every frame
 against the wrong rate - quietly, and only for users whose second device runs at a different rate
 than their first.
+
+Its bail-out tests the context **alone**, never also the worklet node, and that is not tidiness.
+`start()` creates `source` from `this.stream` and only assigns `workletNode` after
+`await addModule()`, so there is a real window where a context and a source exist and the node does
+not. An early return covering that window leaves `source` bound to the stream the caller is about
+to stop, and `start()` then wires that dead source into the graph: socket up, channel relaying
+silence for the rest of the session, nothing reporting it. The worklet connect is guarded instead,
+because `start()` has its own `source.connect(workletNode)` and reads `this.source` - which is the
+replacement by then.
 
 Only `ch_1` moves. `ch_0` is loopback audio captured from the call and has no device to change.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,35 @@ The backend prompts now ask for inline emphasis on the words an answer turns on,
 
 Each `LiveSuggestion` still carries the `mode` it was *generated* under, and the panel keys off that rather than the current setting, so toggling mid-interview leaves cards already on screen alone. What the mode selects is the presentation around the Markdown: professional promotes the headline line, normal keeps the 🪄 marker in a column of its own - prepending it to the content instead would swallow whatever structure the answer opens with.
 
+### Assistant lifecycle
+
+`RunningState` is what every control on the bar is gated on, and `Starting` and `Stopping` disable
+all of them - Stop included. So the one invariant `useAssistantService` has to hold is that the
+state always lands back on a terminal value, whatever went wrong on the way. `stopAssistant`
+returns to `Idle` in a `finally`, and tears the four services down through `Promise.allSettled`
+rather than `Promise.all`: `all` rejects on the first one that throws and abandons the other three,
+so a single failing teardown used to leave the rest running *and* strand the app in `Stopping`
+with no reachable control - unrecoverable without restarting the app, mid-interview. A partial
+failure is now a toast rather than a throw, because there is nothing left for a caller to do about
+it and the session is over either way.
+
+The failed-start path is the mirror of that, and it belongs in exactly one place. `startAssistant`
+already tears both services down and returns to `Idle` in its own `catch`, so `doStart` in
+[control-panel/index.tsx](src/renderer/components/custom/control-panel/index.tsx) reports the error
+and stops there. Calling `stopAssistant()` after it, as it used to, walked the button through a
+three-second `Stopping` for a session that never started, and that call's own failure landed
+outside the `try` as an unhandled rejection.
+
+`useMediaDevices` reports `ready` alongside the device list because an empty list means two
+different things - `enumerateDevices()` has not answered yet, and this machine has none - and the
+control panel renders a destructive badge and refuses Start on the second. Reading them as one
+put a red `!` on a working microphone for the first frames after every launch, and refused a Start
+pressed quickly with a message naming a device that was there all along. An unset
+`audioInputDeviceName` is a third state again, and also not "missing": `AudioGroup` is choosing
+the default at that moment, in an effect - never in the render body, where the store write
+re-enters React mid-commit and a failed IPC call rolls the value back into the same condition that
+triggered it, one write per frame.
+
 ### Interview language
 
 One setting decides three things: which AssemblyAI speech model transcribes the call, what language suggestions come back in, and the language of the exported report. `Language` is mirrored across the processes the way `SuggestionMode` is - [src/main/types/language.ts](src/main/types/language.ts) for the request bodies, [src/renderer/types/language.ts](src/renderer/types/language.ts) for the same enum plus the display metadata the picker needs. Six languages, because that is what `universal-streaming-multilingual` transcribes: offering one the ASR cannot hear would not degrade, it would answer a question that was never asked.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,8 @@ One setting decides three things: which AssemblyAI speech model transcribes the 
 
 Two guards in `AudioWsStream` make that safe, and both protect against the same failure - two sockets on one channel, one of them orphaned and still relaying audio into a dead session. `ws.onclose` ignores a close from a socket that is no longer `this.ws`, since that is the tail of a replacement rather than a disconnect; and the `switching` flag suppresses the ordinary backoff reconnect for the close `setLanguage` causes itself, which it then handles immediately instead of after `WS_RETRY_BASE_DELAY_MS`. `connectWebSocket` rebuilds the URL per attempt rather than capturing it, which is what lets a reconnect pick up the new language at all.
 
+Two consequences of that first guard. `setLanguage` has to report `channelDisconnected` itself rather than leaving it to `onclose`: `new WebSocket` assigns `this.ws` synchronously, so the old socket's close event always arrives after the replacement exists and is correctly ignored. And `setLanguage` keys its own no-op check on `this.ws` rather than on `active`, which `start()` only sets *after* its first connect returns - in that window a socket exists on the old language and an `active` check would skip it.
+
 The setting is persisted *before* the reconnect and never rolled back on failure: a failed reconnect that reverted the setting would leave the user with no route to the language they picked, whereas leaving it set means stopping and starting the assistant recovers.
 
 The trigger shows the code (`EN`, `ES`) next to the icon for the same reason the tooltip names the language - the one question this control has to answer at a glance is what it is currently set to.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,24 @@ The backend prompts now ask for inline emphasis on the words an answer turns on,
 
 Each `LiveSuggestion` still carries the `mode` it was *generated* under, and the panel keys off that rather than the current setting, so toggling mid-interview leaves cards already on screen alone. What the mode selects is the presentation around the Markdown: professional promotes the headline line, normal keeps the 🪄 marker in a column of its own - prepending it to the content instead would swallow whatever structure the answer opens with.
 
+### Interview language
+
+One setting decides three things: which AssemblyAI speech model transcribes the call, what language suggestions come back in, and the language of the exported report. `Language` is mirrored across the processes the way `SuggestionMode` is - [src/main/types/language.ts](src/main/types/language.ts) for the request bodies, [src/renderer/types/language.ts](src/renderer/types/language.ts) for the same enum plus the display metadata the picker needs. Six languages, because that is what `universal-streaming-multilingual` transcribes: offering one the ASR cannot hear would not degrade, it would answer a question that was never asked.
+
+**English is the absence of the feature.** `buildStreamingUrl` sends no `language` parameter at all for English rather than `language=en`, and the backend defaults the request field, so a session that never touches the picker produces exactly the traffic it produced before this existed.
+
+`configStore.getConfig()` resolves the language on the way *out*, not on the way in. The disk holds whatever some build wrote - a code a later release dropped, or one an older release never knew - and every consumer reads through `getConfig`, so that is the single place an unknown code can be stopped before it reaches the ASR URL and three request bodies. `test/language.test.mjs` pins it.
+
+**The picker stays live mid-interview**, unlike Audio and Model, because an interview that switches language is the case it exists for and not one the candidate can prepare for by restarting. The two halves of the setting move at different speeds and `useInterviewLanguage` is where that is reconciled. Suggestions need nothing: every request reads the config store as it is built, so the next one already follows. The ASR carries its language as a *connection* parameter, so `liveTranscriptionService.setLanguage()` tears both sockets down and re-opens them - a second or two of gap, and whatever utterance was mid-flight is orphaned, which is why the button shows a spinner rather than pretending the change was instant and why the menu says so before the user commits.
+
+Two guards in `AudioWsStream` make that safe, and both protect against the same failure - two sockets on one channel, one of them orphaned and still relaying audio into a dead session. `ws.onclose` ignores a close from a socket that is no longer `this.ws`, since that is the tail of a replacement rather than a disconnect; and the `switching` flag suppresses the ordinary backoff reconnect for the close `setLanguage` causes itself, which it then handles immediately instead of after `WS_RETRY_BASE_DELAY_MS`. `connectWebSocket` rebuilds the URL per attempt rather than capturing it, which is what lets a reconnect pick up the new language at all.
+
+The setting is persisted *before* the reconnect and never rolled back on failure: a failed reconnect that reverted the setting would leave the user with no route to the language they picked, whereas leaving it set means stopping and starting the assistant recovers.
+
+The trigger shows the code (`EN`, `ES`) next to the icon for the same reason the tooltip names the language - the one question this control has to answer at a glance is what it is currently set to.
+
+The app's own chrome is **not** localised, deliberately: an English button on a Spanish interview is an inconvenience, an English transcript of Spanish speech is a wrong answer read out loud.
+
 ### Routing
 
 Hash-based router (required for Electron `file://` protocol). Routes: `/` (index, redirects based on login state) -> `/auth/login`, `/auth/signup`, or `/auth/forgot-password` -> `/main` (interview UI) -> `/payment`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,13 +116,15 @@ triggered it, one write per frame.
 
 ### Interview language
 
-One setting decides three things: which AssemblyAI speech model transcribes the call, what language suggestions come back in, and the language of the exported report. `Language` is mirrored across the processes the way `SuggestionMode` is - [src/main/types/language.ts](src/main/types/language.ts) for the request bodies, [src/renderer/types/language.ts](src/renderer/types/language.ts) for the same enum plus the display metadata the picker needs. Six languages, because that is what `universal-streaming-multilingual` transcribes: offering one the ASR cannot hear would not degrade, it would answer a question that was never asked.
+One setting decides three things: which speech model transcribes the call, what language suggestions come back in, and the language of the exported report. `Language` is mirrored across the processes the way `SuggestionMode` is - [src/main/types/language.ts](src/main/types/language.ts) for the request bodies, [src/renderer/types/language.ts](src/renderer/types/language.ts) for the same enum plus the display metadata the picker needs. 28 languages, which is what the backend's Deepgram Nova-3 provider streams: offering one the ASR cannot hear would not degrade, it would answer a question that was never asked. It was six while the backend was AssemblyAI-only.
+
+A backend still configured for AssemblyAI resolves a language it cannot hear back to English rather than faking it, so a client ahead of its backend degrades one session instead of breaking it. `test/language.test.mjs` pins the two mirrors staying in step, which is the failure the widening made likely: an enum member with no picker entry renders a blank trigger, and a picker entry with no enum member resolves straight back to English when picked. The menu is capped and scrolls, because it opens upward from the bottom-most control into an overflow-hidden `main` - an uncapped 28-item list runs off the top of the window rather than flipping.
 
 **English is the absence of the feature.** `buildStreamingUrl` sends no `language` parameter at all for English rather than `language=en`, and the backend defaults the request field, so a session that never touches the picker produces exactly the traffic it produced before this existed.
 
 `configStore.getConfig()` resolves the language on the way *out*, not on the way in. The disk holds whatever some build wrote - a code a later release dropped, or one an older release never knew - and every consumer reads through `getConfig`, so that is the single place an unknown code can be stopped before it reaches the ASR URL and three request bodies. `test/language.test.mjs` pins it.
 
-**The picker stays live mid-interview**, unlike Audio and Model, because an interview that switches language is the case it exists for and not one the candidate can prepare for by restarting. The two halves of the setting move at different speeds and `useInterviewLanguage` is where that is reconciled. Suggestions need nothing: every request reads the config store as it is built, so the next one already follows. The ASR carries its language as a *connection* parameter, so `liveTranscriptionService.setLanguage()` tears both sockets down and re-opens them - a second or two of gap, and whatever utterance was mid-flight is orphaned, which is why the button shows a spinner rather than pretending the change was instant and why the menu says so before the user commits.
+**The picker stays live mid-interview**, unlike Model, because an interview that switches language is the case it exists for and not one the candidate can prepare for by restarting. The two halves of the setting move at different speeds and `useInterviewLanguage` is where that is reconciled. Suggestions need nothing: every request reads the config store as it is built, so the next one already follows. The ASR carries its language as a *connection* parameter, so `liveTranscriptionService.setLanguage()` tears both sockets down and re-opens them - a second or two of gap, and whatever utterance was mid-flight is orphaned, which is why the button shows a spinner rather than pretending the change was instant and why the menu says so before the user commits.
 
 Two guards in `AudioWsStream` make that safe, and both protect against the same failure - two sockets on one channel, one of them orphaned and still relaying audio into a dead session. `ws.onclose` ignores a close from a socket that is no longer `this.ws`, since that is the tail of a replacement rather than a disconnect; and the `switching` flag suppresses the ordinary backoff reconnect for the close `setLanguage` causes itself, which it then handles immediately instead of after `WS_RETRY_BASE_DELAY_MS`. `connectWebSocket` rebuilds the URL per attempt rather than capturing it, which is what lets a reconnect pick up the new language at all.
 
@@ -133,6 +135,46 @@ The setting is persisted *before* the reconnect and never rolled back on failure
 The trigger shows the code (`EN`, `ES`) next to the icon for the same reason the tooltip names the language - the one question this control has to answer at a glance is what it is currently set to.
 
 The app's own chrome is **not** localised, deliberately: an English button on a Spanish interview is an inconvenience, an English transcript of Spanish speech is a wrong answer read out loud.
+
+### Audio input device
+
+**The microphone can be changed mid-interview**, and for the same reason the language can: the case
+it exists for only shows up once the session is running. A headset that dies, is unplugged, or was
+the wrong device to begin with is noticed when the interviewer says they cannot hear you, and the
+control used to be locked at exactly that moment - the only fix was stopping the assistant, which
+drops the transcript and the suggestion history with it.
+
+It is cheaper than the language switch, and the difference is worth keeping straight. The device is
+only what feeds the worklet; it is **not** a connection parameter. So `AudioWsStream.setStream()`
+replaces the `MediaStreamAudioSourceNode` while the socket, the provider session and any utterance
+in flight all survive. Nothing reconnects, there is no gap in the transcript, and the dialog
+therefore promises the opposite of what the language menu warns about. Reaching for `setLanguage`'s
+machinery here would reintroduce the gap this avoids.
+
+Two things `liveTranscriptionService.setAudioInputDevice()` has to hold, both pinned by
+`test/audio-device-switch.test.mjs`. **The replacement stream is acquired before anything is torn
+down**, and the previous one stopped only after the swap succeeds, so a device that is unplugged,
+held by another app, or refused by permissions leaves the interview on the microphone it already
+had. Releasing first reads as the obvious cleanup order and works every time the new device is
+present; on the one path that matters it leaves the session with no microphone at all, mid-answer.
+And a stream that finishes opening *after* the session stopped is released rather than left holding
+the device with its indicator light on, since nothing else keeps a reference to it.
+
+`setStream` reuses the existing `AudioContext` rather than building one. Its `sampleRate` is fixed
+at construction and `convertTo16kPcm` reads it, so a fresh context would resample every frame
+against the wrong rate - quietly, and only for users whose second device runs at a different rate
+than their first.
+
+Only `ch_1` moves. `ch_0` is loopback audio captured from the call and has no device to change.
+
+The setting is persisted before the swap and never rolled back on failure, the same as the language
+picker: a failed swap leaves the audio running, so reverting would only remove the user's route to
+the device they picked.
+
+The tests are source-level, unusually for this directory - every other one loads a built
+main-process module, and this is renderer code with no runtime harness. They are worth the
+awkwardness because the ordering above is what a later tidy-up breaks, with no symptom a type
+checker or a linter can see.
 
 ### Navigation and external links
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,31 @@ The trigger shows the code (`EN`, `ES`) next to the icon for the same reason the
 
 The app's own chrome is **not** localised, deliberately: an English button on a Spanish interview is an inconvenience, an English transcript of Spanish speech is a wrong answer read out loud.
 
+### Navigation and external links
+
+The panels render Markdown that came from a language model, and `remark-gfm` autolinks bare URLs,
+so an anchor in this app is not necessarily one a person wrote. `installNavigationGuard()`
+([src/main/navigation-guard.ts](src/main/navigation-guard.ts)) is installed before the window's
+first load and closes the two routes that follow from that, neither of which announced itself.
+
+`setWindowOpenHandler` denies **every** new window. A `target="_blank"` anchor - which is what
+`SafeMarkdown` renders - asks Electron for one, and with no handler installed the default is to
+make it: a chromeless BrowserWindow with no address bar showing a page the user did not choose.
+A web URL is handed to the real browser instead, through `setImmediate` as Electron's own
+guidance requires.
+
+`will-navigate` pins the window to the app's own document. An anchor without a target navigates
+the frame it is in, and that frame is the app - preload runs on whatever document loads next, so
+a remote page would inherit `window.electronAPI`, and with it the session token through
+`config.get()` and the candidate's CV through `account.get()`. `file:` origins serialize to
+`"null"`, so the packaged build is matched on its exact document URL rather than on an origin
+comparison that could never hold.
+
+Both routes and the `external:open` IPC handler go through the same `openExternally()`, which
+allows `http:`, `https:` and `mailto:` only. `shell.openExternal` delegates to the OS protocol
+handler, so `file:` launches whatever the path points at and a registered custom scheme runs
+whatever claimed it. `test/navigation-guard.test.mjs` pins all three.
+
 ### Routing
 
 Hash-based router (required for Electron `file://` protocol). Routes: `/` (index, redirects based on login state) -> `/auth/login`, `/auth/signup`, or `/auth/forgot-password` -> `/main` (interview UI) -> `/payment`.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ pnpm test:main     # main-process checks
 ### Configuration
 
 - Set profile (CV, job description)
-- Select microphone
+- Select microphone (changeable mid-interview, without interrupting transcription)
 - Start assistant
 
 ## Use Cases

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, Menu } from 'electron';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -22,6 +22,7 @@ import { registerLiveSuggestionHandlers } from './ipc/suggestion-live.js';
 import { registerToolsHandlers } from './ipc/tools.js';
 import { initializeAudioLoopback, registerTranscriptHandlers } from './ipc/transcript.js';
 import { registerWindowHandlers } from './ipc/window.js';
+import { installNavigationGuard } from './navigation-guard.js';
 import { autoUpdaterService } from './services/auto-updater.service.js';
 import { healthCheckService } from './services/health-check.service.js';
 import { transcriptService } from './services/transcript.service.js';
@@ -172,14 +173,20 @@ async function createWindow() {
   // Clear cache before loading
   await win.webContents.session.clearCache();
 
+  // Installed before the load, so the guard is in place for the app's very first document.
+  // `web-contents-created` fires for the window created above, and the handler is idempotent
+  // enough to survive a relaunch because the window is only ever created once per process.
   if (EnvUtil.isDev()) {
-    win.loadURL('http://localhost:15173');
+    const devUrl = 'http://localhost:15173';
+    installNavigationGuard(devUrl);
+    win.loadURL(devUrl);
     win.webContents.openDevTools();
   } else {
     // Use app.getAppPath() for conventional path resolution
     // This works correctly whether the app is packaged or not
     const distPath = path.join(app.getAppPath(), 'dist', 'index.html');
     console.log('Loading from:', distPath);
+    installNavigationGuard(pathToFileURL(distPath).href);
     win.loadFile(distPath);
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -174,8 +174,8 @@ async function createWindow() {
   await win.webContents.session.clearCache();
 
   // Installed before the load, so the guard is in place for the app's very first document.
-  // `web-contents-created` fires for the window created above, and the handler is idempotent
-  // enough to survive a relaunch because the window is only ever created once per process.
+  // Idempotent, because this function runs again when the single-instance lock recovers a
+  // destroyed window and `web-contents-created` is an app-level event.
   if (EnvUtil.isDev()) {
     const devUrl = 'http://localhost:15173';
     installNavigationGuard(devUrl);

--- a/src/main/ipc/external.ts
+++ b/src/main/ipc/external.ts
@@ -1,16 +1,12 @@
 import { ipcMain, shell } from 'electron';
 
+import { openExternally } from '../navigation-guard.js';
+
 export function registerExternalHandlers(): void {
-  ipcMain.handle('external:open', async (_event, url: string) => {
-    try {
-      if (!url || typeof url !== 'string') return { success: false, error: 'invalid-url' };
-      await shell.openExternal(url);
-      return { success: true };
-    } catch (err: unknown) {
-      console.warn('[ExternalHandlers] external:open error:', err);
-      return { success: false, error: err instanceof Error ? err.message : String(err) };
-    }
-  });
+  // Shared with the window-open handler rather than calling shell.openExternal directly, so a
+  // link takes the same route and the same scheme check whichever way it arrives. openExternal
+  // hands the URL to the OS protocol handler, so `file:` launches what the path points at.
+  ipcMain.handle('external:open', async (_event, url: string) => openExternally(url));
 
   ipcMain.handle('external:open-file', async (_event, filePath: string) => {
     const err = await shell.openPath(filePath);

--- a/src/main/navigation-guard.ts
+++ b/src/main/navigation-guard.ts
@@ -1,0 +1,101 @@
+import { app, shell } from 'electron';
+
+/**
+ * Schemes `shell.openExternal` is allowed to hand to the operating system.
+ *
+ * openExternal delegates to the OS protocol handler, so `file:` launches whatever the path points
+ * at and a registered custom scheme runs whatever claimed it. Only the three that mean "show this
+ * to the user in their own application" are permitted.
+ */
+const OPENABLE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:']);
+
+export function isOpenableExternally(url: string): boolean {
+  try {
+    return OPENABLE_PROTOCOLS.has(new URL(url).protocol);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Open a URL in the user's own browser, or refuse it.
+ *
+ * Shared by the `external:open` IPC handler and the window-open handler below, so a link takes
+ * the same route whether the renderer asked for it explicitly or a `target="_blank"` anchor did.
+ */
+export async function openExternally(url: string): Promise<{ success: boolean; error?: string }> {
+  if (!url || typeof url !== 'string') return { success: false, error: 'invalid-url' };
+  if (!isOpenableExternally(url)) {
+    console.warn('[NavigationGuard] Refused to open a non-web URL:', url);
+    return { success: false, error: 'unsupported-scheme' };
+  }
+
+  try {
+    await shell.openExternal(url);
+    return { success: true };
+  } catch (err: unknown) {
+    console.warn('[NavigationGuard] openExternal error:', err);
+    return { success: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * Keep the app's own web contents on the app.
+ *
+ * The panels render Markdown that came from a language model, and `remark-gfm` autolinks bare
+ * URLs, so an anchor in this app is not necessarily one anybody wrote. Two things follow from
+ * that, and neither was covered before.
+ *
+ * A `target="_blank"` anchor asks Electron for a new window, and with no handler installed the
+ * default is to make one: a chromeless BrowserWindow, no address bar, showing a page the user did
+ * not choose. Every one of those is denied and handed to the real browser instead, which is both
+ * safer and what the user expected from a link.
+ *
+ * An anchor without a target navigates the frame it is in, and that frame is the app - carrying
+ * the preload bridge with it, since preload runs on whatever document loads next. A remote page
+ * inheriting `window.electronAPI` would have the session token through `config.get()` and the
+ * candidate's CV through `account.get()`. `will-navigate` pins the window to the app's own
+ * document; the dev server and the packaged `file://` bundle are the only origins it may hold.
+ */
+export function installNavigationGuard(appUrl: string): void {
+  let appOrigin: string;
+  try {
+    appOrigin = new URL(appUrl).origin;
+  } catch {
+    appOrigin = '';
+  }
+
+  app.on('web-contents-created', (_event, contents) => {
+    contents.setWindowOpenHandler(({ url }) => {
+      // setImmediate, per Electron's own guidance: openExternal must not run inside the handler.
+      if (isOpenableExternally(url)) {
+        setImmediate(() => void openExternally(url));
+      } else {
+        console.warn('[NavigationGuard] Blocked a window for:', url);
+      }
+      return { action: 'deny' };
+    });
+
+    contents.on('will-navigate', (event, navigationUrl) => {
+      let target: URL;
+      try {
+        target = new URL(navigationUrl);
+      } catch {
+        event.preventDefault();
+        return;
+      }
+
+      // `file:` origins serialize to "null", so the packaged build is matched on the document it
+      // is already showing rather than on an origin comparison that can never hold.
+      const sameDocument =
+        target.href === appUrl || (appOrigin !== '' && target.origin === appOrigin);
+      if (sameDocument) return;
+
+      event.preventDefault();
+      console.warn('[NavigationGuard] Blocked navigation to:', navigationUrl);
+      if (isOpenableExternally(navigationUrl)) {
+        setImmediate(() => void openExternally(navigationUrl));
+      }
+    });
+  });
+}

--- a/src/main/navigation-guard.ts
+++ b/src/main/navigation-guard.ts
@@ -57,7 +57,15 @@ export async function openExternally(url: string): Promise<{ success: boolean; e
  * candidate's CV through `account.get()`. `will-navigate` pins the window to the app's own
  * document; the dev server and the packaged `file://` bundle are the only origins it may hold.
  */
+let installed = false;
+
 export function installNavigationGuard(appUrl: string): void {
+  // `createWindow()` runs again when the single-instance lock recovers a destroyed window, and
+  // `web-contents-created` is an app-level event: without this the second call would stack a
+  // duplicate will-navigate listener on every web contents for the rest of the process.
+  if (installed) return;
+  installed = true;
+
   let appOrigin: string;
   try {
     appOrigin = new URL(appUrl).origin;

--- a/src/main/services/health-check.service.ts
+++ b/src/main/services/health-check.service.ts
@@ -13,6 +13,19 @@ import { pushNotificationService } from './push-notification.service.js';
 const SUCCESS_INTERVAL = 5 * 1000; // 5 seconds
 const FAILURE_INTERVAL = 1 * 1000; // 1 second
 
+// A backend that is down is usually down for longer than a second, and the first retry is the
+// only one that benefits from being immediate. Without a ceiling the loop below polls at 1 Hz
+// for as long as the app is open - a laptop left overnight on a dropped connection makes tens of
+// thousands of failing requests, and every installed client comes back at the same rate the
+// moment a real outage ends. Backoff is capped rather than unbounded so recovery is still
+// noticed within half a minute, which is what the reconnect notice in the UI is waiting on.
+const MAX_FAILURE_INTERVAL = 30 * 1000;
+const FAILURE_BACKOFF_FACTOR = 2;
+
+function nextFailureInterval(current: number): number {
+  return Math.min(current * FAILURE_BACKOFF_FACTOR, MAX_FAILURE_INTERVAL);
+}
+
 export class HealthCheckService {
   private running = false;
   private client = new HealthCheckApi();
@@ -64,6 +77,8 @@ export class HealthCheckService {
   /** Backend ping loop */
   private startBackendLoop(): void {
     (async () => {
+      let failureInterval = FAILURE_INTERVAL;
+
       while (this.running) {
         let backendLive = false;
         try {
@@ -74,13 +89,17 @@ export class HealthCheckService {
         }
 
         if (!backendLive) {
-          console.log('[HealthCheckService] Backend not live');
+          console.log(`[HealthCheckService] Backend not live, next check in ${failureInterval}ms`);
         }
 
         // Update app state
         appStateService.updateState({ isBackendLive: backendLive });
 
-        const next = backendLive ? SUCCESS_INTERVAL : FAILURE_INTERVAL;
+        // Reset on the way back up, so one blip does not leave the app checking slowly for the
+        // rest of the session.
+        const next = backendLive ? SUCCESS_INTERVAL : failureInterval;
+        failureInterval = backendLive ? FAILURE_INTERVAL : nextFailureInterval(failureInterval);
+
         await safeSleep(next);
       }
     })();
@@ -89,12 +108,17 @@ export class HealthCheckService {
   /** Client ping loop */
   private startClientLoop(): void {
     (async () => {
+      let failureInterval = FAILURE_INTERVAL;
+
       while (this.running) {
         const state = appStateService.getState();
 
-        // skip if not logged in
+        // skip if not logged in. Kept at FAILURE_INTERVAL: it makes no request, so it costs a
+        // timer wake-up rather than traffic, and it is what decides how soon after a sign-in the
+        // credits and role reach the UI.
         if (!state.isLoggedIn) {
           await safeSleep(FAILURE_INTERVAL);
+          failureInterval = FAILURE_INTERVAL;
           continue;
         }
 
@@ -117,9 +141,11 @@ export class HealthCheckService {
               userRole: res.data?.user_role,
             });
           }
+          failureInterval = FAILURE_INTERVAL;
         } catch (error) {
           console.error('[HealthCheckService] Client ping error:', error);
-          nextInterval = FAILURE_INTERVAL;
+          nextInterval = failureInterval;
+          failureInterval = nextFailureInterval(failureInterval);
         }
 
         await safeSleep(nextInterval);

--- a/src/main/services/suggestion-action.service.ts
+++ b/src/main/services/suggestion-action.service.ts
@@ -218,6 +218,7 @@ export class ActionSuggestionService {
       transcripts: transcripts.slice(-TRANSCRIPT_UPLOAD_LIMIT),
       image_names: [...this.uploadedImageNames],
       mode: conf.professionalMode ? SuggestionMode.Professional : SuggestionMode.Normal,
+      language: conf.language,
     };
 
     const lastQuestion = this.getLastInterviewerQuestion(transcripts);

--- a/src/main/services/suggestion-live.service.ts
+++ b/src/main/services/suggestion-live.service.ts
@@ -125,6 +125,7 @@ class LiveSuggestionService {
         transcripts: transcripts.slice(-TRANSCRIPT_UPLOAD_LIMIT),
         mode,
         turn_verdict: turnVerdict,
+        language: conf.language,
       };
 
       armStallTimer(LIVE_SUGGESTION_TTFB_MS);

--- a/src/main/services/tools.service.ts
+++ b/src/main/services/tools.service.ts
@@ -21,6 +21,14 @@ class ToolsService {
     const transcripts = appStateService.getState().transcripts;
     const suggestions = appStateService.getState().liveSuggestions;
 
+    // Checked before the request, not after. Summarizing an empty interview is a billed model
+    // call whose only possible output is invented, and it lands in a document the candidate is
+    // told is a record of their interview. The export button is live whenever the assistant is
+    // idle, which includes every launch before the first session.
+    if (transcripts.length === 0 && suggestions.length === 0) {
+      throw new Error('There is nothing to export yet. Run an interview first.');
+    }
+
     // Call the API to generate the summary text
     const conf = configStore.getConfig();
     const response = await this.llmApi.generateSummary({

--- a/src/main/services/tools.service.ts
+++ b/src/main/services/tools.service.ts
@@ -22,10 +22,14 @@ class ToolsService {
     const suggestions = appStateService.getState().liveSuggestions;
 
     // Call the API to generate the summary text
+    const conf = configStore.getConfig();
     const response = await this.llmApi.generateSummary({
-      config: configStore.getConfig().llmConf,
+      config: conf.llmConf,
       username,
       transcripts,
+      // The exported report is written in the interview's language too. A Spanish interview
+      // summarised in English is a document the candidate cannot hand to anyone involved in it.
+      language: conf.language,
     } as GenerateSummarizeRequest);
     if (response.error) {
       throw new Error(response.error.message);

--- a/src/main/services/transcript.service.ts
+++ b/src/main/services/transcript.service.ts
@@ -4,9 +4,11 @@ import {
   SELF_PARTIAL_STALE_MS,
   TRANSCRIPT_INTER_TRANSCRIPT_GAP_MS,
 } from '../consts.js';
+import { configStore } from '../store/config.store.js';
 import { Speaker, Transcript } from '../types/app-state.js';
 import { RequestTurnVerdict } from '../types/llm.js';
 import { classifyInterviewerTurn, TurnVerdict } from '../utils/interviewer-turn.js';
+import { transcriptSeparator } from '../utils/transcript-join.js';
 import { appStateService } from './app-state.service.js';
 import { liveSuggestionService } from './suggestion-live.service.js';
 
@@ -86,6 +88,11 @@ class TranscriptService {
     if (this.otherPartialTranscript) allTranscripts.push(this.otherPartialTranscript);
     allTranscripts = allTranscripts.filter(Boolean).sort((a, b) => a.timestamp - b.timestamp);
 
+    // Read once per ingest rather than per merge. `getConfig()` reads an in-memory store, and
+    // this function already rebuilds `cleaned` from scratch on every partial, so the cost is
+    // noise next to the loop below.
+    const separator = transcriptSeparator(configStore.getConfig().language);
+
     const cleaned: Transcript[] = [];
     for (const t of allTranscripts) {
       const lastIndex = cleaned.length - 1;
@@ -99,7 +106,7 @@ class TranscriptService {
         lastCleaned.speaker === t.speaker &&
         t.timestamp - lastCleaned.endTimestamp <= TRANSCRIPT_INTER_TRANSCRIPT_GAP_MS
       ) {
-        lastCleaned.text += ' ' + t.text;
+        lastCleaned.text += separator + t.text;
         lastCleaned.endTimestamp = t.endTimestamp;
       } else {
         cleaned.push({ ...t });

--- a/src/main/store/config.store.ts
+++ b/src/main/store/config.store.ts
@@ -6,11 +6,13 @@
 import ElectronStore from 'electron-store';
 
 import { OPACITY_DEFAULT } from '../consts.js';
+import { DEFAULT_LANGUAGE, Language, resolveLanguage } from '../types/language.js';
 import { LLMConfig } from '../types/llm.js';
 
 // Runtime configuration (matches Config type in frontend)
 export interface RuntimeConfig {
-  language: string;
+  /** Interview language: what the ASR transcribes and what suggestions come back in. */
+  language: Language;
   sessionToken: string;
   rememberMe: boolean;
   email: string;
@@ -36,7 +38,7 @@ export interface RuntimeConfig {
 
 // Default runtime configuration
 const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
-  language: 'en',
+  language: DEFAULT_LANGUAGE,
   sessionToken: '',
   rememberMe: true,
   email: '',
@@ -102,7 +104,15 @@ class ConfigStore {
   getConfig(): RuntimeConfig {
     const stored: StoredRuntime = { ...this.store.get('runtime', DEFAULT_RUNTIME_CONFIG) };
     delete stored.interviewConf;
-    return { ...DEFAULT_RUNTIME_CONFIG, ...stored } as RuntimeConfig;
+    const config = { ...DEFAULT_RUNTIME_CONFIG, ...stored } as RuntimeConfig;
+
+    // Resolved on the way out, not on the way in. The disk holds whatever some build wrote -
+    // a language a later release dropped, or one an older one never knew - and every consumer
+    // reads through here, so this is the one place that can stop an unknown code reaching the
+    // ASR URL and the request bodies.
+    config.language = resolveLanguage(config.language);
+
+    return config;
   }
 
   /**

--- a/src/main/types/language.ts
+++ b/src/main/types/language.ts
@@ -2,9 +2,14 @@
  * The language an interview runs in: what the ASR transcribes and what suggestions come back in.
  *
  * ISO 639-1 codes, mirroring `Language` in the backend's `app/schemas/language.py`. The set is
- * exactly the six languages AssemblyAI's `universal-streaming-multilingual` model supports, and
- * deliberately no wider: offering a language the transcription cannot deliver produces confident
- * answers to a question that was never asked, which is worse than not offering it.
+ * what the backend's streaming ASR provider can hear, and deliberately no wider: offering a
+ * language the transcription cannot deliver produces confident answers to a question that was
+ * never asked, which is worse than not offering it.
+ *
+ * The ceiling used to be six, because that is all AssemblyAI's `universal-streaming-multilingual`
+ * transcribes. It is now what Deepgram Nova-3 streams. A backend still configured for AssemblyAI
+ * resolves a language it cannot hear back to English rather than faking it, so a client ahead of
+ * its backend degrades one session instead of breaking it.
  *
  * `src/renderer/types/language.ts` carries the same enum plus the display metadata the picker
  * needs, the way `SuggestionMode` is mirrored across the two processes.
@@ -16,6 +21,28 @@ export enum Language {
   French = 'fr',
   Portuguese = 'pt',
   Italian = 'it',
+  Dutch = 'nl',
+  Polish = 'pl',
+  Russian = 'ru',
+  Ukrainian = 'uk',
+  Czech = 'cs',
+  Romanian = 'ro',
+  Greek = 'el',
+  Hungarian = 'hu',
+  Swedish = 'sv',
+  Danish = 'da',
+  Norwegian = 'no',
+  Finnish = 'fi',
+  Turkish = 'tr',
+  Hindi = 'hi',
+  Japanese = 'ja',
+  Korean = 'ko',
+  Chinese = 'zh',
+  Vietnamese = 'vi',
+  Thai = 'th',
+  Indonesian = 'id',
+  Arabic = 'ar',
+  Hebrew = 'he',
 }
 
 export const DEFAULT_LANGUAGE = Language.English;

--- a/src/main/types/language.ts
+++ b/src/main/types/language.ts
@@ -1,0 +1,38 @@
+/**
+ * The language an interview runs in: what the ASR transcribes and what suggestions come back in.
+ *
+ * ISO 639-1 codes, mirroring `Language` in the backend's `app/schemas/language.py`. The set is
+ * exactly the six languages AssemblyAI's `universal-streaming-multilingual` model supports, and
+ * deliberately no wider: offering a language the transcription cannot deliver produces confident
+ * answers to a question that was never asked, which is worse than not offering it.
+ *
+ * `src/renderer/types/language.ts` carries the same enum plus the display metadata the picker
+ * needs, the way `SuggestionMode` is mirrored across the two processes.
+ */
+export enum Language {
+  English = 'en',
+  Spanish = 'es',
+  German = 'de',
+  French = 'fr',
+  Portuguese = 'pt',
+  Italian = 'it',
+}
+
+export const DEFAULT_LANGUAGE = Language.English;
+
+const LANGUAGE_CODES = new Set<string>(Object.values(Language));
+
+/**
+ * Map a stored or incoming value onto the enum, falling back to English.
+ *
+ * The config store holds whatever was written to disk, which may be a language a later build
+ * removed or an older build never knew. Sending that through unchecked puts an unknown code on
+ * the ASR URL and in every request body, where the backend can only fall back anyway - so it
+ * resolves here, once, at the point the value leaves the store.
+ */
+export function resolveLanguage(raw: string | null | undefined): Language {
+  if (!raw) return DEFAULT_LANGUAGE;
+
+  const normalized = raw.trim().toLowerCase();
+  return LANGUAGE_CODES.has(normalized) ? (normalized as Language) : DEFAULT_LANGUAGE;
+}

--- a/src/main/types/language.ts
+++ b/src/main/types/language.ts
@@ -1,15 +1,13 @@
 /**
  * The language an interview runs in: what the ASR transcribes and what suggestions come back in.
  *
- * ISO 639-1 codes, mirroring `Language` in the backend's `app/schemas/language.py`. The set is
- * what the backend's streaming ASR provider can hear, and deliberately no wider: offering a
+ * ISO 639-1 codes, mirroring `Language` in the backend's `app/schemas/language.py`, which is
+ * exactly what its Deepgram Nova-3 ASR streams. Deliberately no wider than that: offering a
  * language the transcription cannot deliver produces confident answers to a question that was
  * never asked, which is worse than not offering it.
  *
- * The ceiling used to be six, because that is all AssemblyAI's `universal-streaming-multilingual`
- * transcribes. It is now what Deepgram Nova-3 streams. A backend still configured for AssemblyAI
- * resolves a language it cannot hear back to English rather than faking it, so a client ahead of
- * its backend degrades one session instead of breaking it.
+ * A code this build knows but an older backend does not is resolved back to English there rather
+ * than faked, so a client ahead of its backend degrades one session instead of breaking it.
  *
  * `src/renderer/types/language.ts` carries the same enum plus the display metadata the picker
  * needs, the way `SuggestionMode` is mirrored across the two processes.

--- a/src/main/types/llm.ts
+++ b/src/main/types/llm.ts
@@ -1,4 +1,5 @@
 import { Transcript } from './app-state.js';
+import { Language } from './language.js';
 
 export enum LLMProvider {
   OPENAI = 'openai',
@@ -48,6 +49,12 @@ export interface LLMConfigValidationResult {
 
 export interface LLMRequest {
   config: LLMConfig | null;
+
+  /**
+   * Interview language. Carried on the shared base so the three request kinds cannot drift, and
+   * defaulted server-side, so omitting it against an older deployment still means English.
+   */
+  language?: Language;
 }
 
 /**

--- a/src/main/utils/transcript-join.ts
+++ b/src/main/utils/transcript-join.ts
@@ -1,0 +1,27 @@
+import { Language } from '../types/language.js';
+
+/**
+ * Languages written without spaces between words.
+ *
+ * Kept in step with the backend's `_UNSPACED_LANGUAGES` in `app/services/asr/deepgram.py`, which
+ * applies the same rule when it rejoins the segments of a single utterance. This one covers the
+ * other half: transcripts that arrived as separate finals and are merged here because they fell
+ * inside `TRANSCRIPT_INTER_TRANSCRIPT_GAP_MS` of each other.
+ */
+const UNSPACED_LANGUAGES: ReadonlySet<Language> = new Set([
+  Language.Japanese,
+  Language.Chinese,
+  Language.Thai,
+]);
+
+/**
+ * What to put between two transcript blocks being merged into one.
+ *
+ * A space is a word boundary in English and a visible defect in Japanese, and it does not stop at
+ * the panel: `cleaned` is what the suggestion request carries, so the model is asked to answer a
+ * question with breaks nobody spoke. The backend already avoids inserting them inside an
+ * utterance; joining with a space here would put them back at every merge.
+ */
+export function transcriptSeparator(language: Language): string {
+  return UNSPACED_LANGUAGES.has(language) ? '' : ' ';
+}

--- a/src/main/utils/transcript-join.ts
+++ b/src/main/utils/transcript-join.ts
@@ -3,7 +3,7 @@ import { Language } from '../types/language.js';
 /**
  * Languages written without spaces between words.
  *
- * Kept in step with the backend's `_UNSPACED_LANGUAGES` in `app/services/asr/deepgram.py`, which
+ * Kept in step with the backend's `_UNSPACED_LANGUAGES` in `app/services/asr_service.py`, which
  * applies the same rule when it rejoins the segments of a single utterance. This one covers the
  * other half: transcripts that arrived as separate finals and are merged here because they fell
  * inside `TRANSCRIPT_INTER_TRANSCRIPT_GAP_MS` of each other.

--- a/src/renderer/components/custom/change-password-dialog.tsx
+++ b/src/renderer/components/custom/change-password-dialog.tsx
@@ -54,6 +54,8 @@ export function ChangePasswordDialog({
     onOpenChange(newOpen);
   };
 
+  const passwordsMismatch = confirmPassword !== '' && newPassword !== confirmPassword;
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-106.25">
@@ -69,6 +71,8 @@ export function ChangePasswordDialog({
             <div className="relative">
               <InputPassword
                 id="current-password"
+                name="current-password"
+                autoComplete="current-password"
                 value={currentPassword}
                 onChange={(e) => setCurrentPassword(e.target.value)}
                 placeholder="Enter current password"
@@ -83,6 +87,8 @@ export function ChangePasswordDialog({
             <div className="relative">
               <InputPassword
                 id="new-password"
+                name="new-password"
+                autoComplete="new-password"
                 value={newPassword}
                 onChange={(e) => setNewPassword(e.target.value)}
                 placeholder="Enter new password"
@@ -97,6 +103,8 @@ export function ChangePasswordDialog({
             <div className="relative">
               <InputPassword
                 id="confirm-password"
+                name="confirm-password"
+                autoComplete="new-password"
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}
                 placeholder="Confirm new password"
@@ -128,7 +136,20 @@ export function ChangePasswordDialog({
             {loading ? 'Changing...' : 'Change Password'}
           </Button>
         </DialogFooter>
-        {error && <div className="text-sm text-red-600 mt-2">{error}</div>}
+        {/* Says why the button is dead. A mismatch is the one condition above that the user
+            cannot see from the fields themselves - both are masked - so without this the
+            dialog silently refuses to submit and gives no reason. Held back until the confirm
+            field has something in it, so it is not an error for a half-typed entry. */}
+        {passwordsMismatch && (
+          <div role="alert" className="text-sm text-destructive mt-2">
+            The new passwords do not match.
+          </div>
+        )}
+        {error && (
+          <div role="alert" className="text-sm text-destructive mt-2">
+            {error}
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/renderer/components/custom/configuration-dialog.tsx
+++ b/src/renderer/components/custom/configuration-dialog.tsx
@@ -20,6 +20,34 @@ const MAX_FIELD_LENGTH = 128_000;
 // Kept in sync with the backend's MAX_USERNAME_LENGTH (app/cfg/llm.py)
 const MAX_NAME_LENGTH = 1_000;
 
+/**
+ * How much of a long field's budget is left, once it is close enough to matter.
+ *
+ * `maxLength` on a textarea truncates a paste silently, which for these two fields means a CV or
+ * a job description arriving 2,000 characters shorter than the one the user copied, with nothing
+ * on screen having said so. Hidden below the threshold: a counter over an empty box is noise,
+ * and the limit is generous enough that most sessions never approach it.
+ */
+const LIMIT_NOTICE_RATIO = 0.9;
+
+function FieldLimitNotice({ value, max }: { value: string; max: number }) {
+  if (value.length < max * LIMIT_NOTICE_RATIO) return null;
+
+  const atLimit = value.length >= max;
+  return (
+    <p
+      className={`text-[11px] tabular-nums ${atLimit ? 'text-destructive' : 'text-muted-foreground'}`}
+      // Announced when it changes rather than only on focus: the moment it matters is a paste
+      // that was cut short, which is not a keystroke the user is watching the counter for.
+      role="status"
+    >
+      {atLimit
+        ? `Character limit reached (${max.toLocaleString()}). Extra text was not added.`
+        : `${(max - value.length).toLocaleString()} characters left`}
+    </p>
+  );
+}
+
 interface ConfigurationDialogProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
@@ -77,7 +105,11 @@ export default function ConfigurationDialog({ isOpen, onOpenChange }: Configurat
         throw new Error('Electron API not available');
       }
 
-      const result = await electron.account.update(name, profileData, context);
+      // Trimmed on the way out, not just validated. The Save button is already gated on the
+      // trimmed name being non-empty, so a name of pure whitespace could never be saved - but a
+      // name with a trailing space could, and it is the string the prompts address the candidate
+      // by. The same goes for a CV pasted with a leading blank line.
+      const result = await electron.account.update(name.trim(), profileData.trim(), context.trim());
       if (!result.success) {
         throw new Error(result.error || 'Failed to save configuration');
       }
@@ -106,10 +138,18 @@ export default function ConfigurationDialog({ isOpen, onOpenChange }: Configurat
         <div className="flex-1 overflow-auto p-2">
           <div className="space-y-5">
             <div className="grid gap-2">
-              <label className="text-xs font-medium text-muted-foreground mb-1.5 block">
-                Full Name <span className="text-destructive">*</span>
+              <label
+                htmlFor="config-full-name"
+                className="text-xs font-medium text-muted-foreground mb-1.5 block"
+              >
+                Full Name{' '}
+                <span className="text-destructive" aria-hidden="true">
+                  *
+                </span>
               </label>
               <Input
+                id="config-full-name"
+                required
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="Enter your profile name"
@@ -119,10 +159,21 @@ export default function ConfigurationDialog({ isOpen, onOpenChange }: Configurat
             </div>
 
             <div className="grid gap-2">
-              <label className="text-xs font-medium text-muted-foreground mb-1.5 block">
-                Profile <span className="text-destructive">*</span>
-              </label>
+              <div className="flex items-baseline justify-between gap-2 mb-1.5">
+                <label
+                  htmlFor="config-profile"
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  Profile{' '}
+                  <span className="text-destructive" aria-hidden="true">
+                    *
+                  </span>
+                </label>
+                <FieldLimitNotice value={profileData} max={MAX_FIELD_LENGTH} />
+              </div>
               <Textarea
+                id="config-profile"
+                required
                 value={profileData}
                 onChange={(e) => setProfileData(e.target.value)}
                 placeholder="Enter your profile information. (e.g. your CV/resume, LinkedIn profile, or a brief bio)"
@@ -132,10 +183,17 @@ export default function ConfigurationDialog({ isOpen, onOpenChange }: Configurat
             </div>
 
             <div className="grid gap-2">
-              <label className="text-xs font-medium text-muted-foreground mb-1.5 block">
-                Context (Recommended)
-              </label>
+              <div className="flex items-baseline justify-between gap-2 mb-1.5">
+                <label
+                  htmlFor="config-context"
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  Context (Recommended)
+                </label>
+                <FieldLimitNotice value={context} max={MAX_FIELD_LENGTH} />
+              </div>
               <Textarea
+                id="config-context"
                 value={context}
                 onChange={(e) => setContext(e.target.value)}
                 placeholder="Enter the context you are targeting. (e.g. the job description, role requirements or any other information)"

--- a/src/renderer/components/custom/control-panel/audio-group.tsx
+++ b/src/renderer/components/custom/control-panel/audio-group.tsx
@@ -73,8 +73,16 @@ export function AudioGroup({
               className={cn(BAR_ICON_BUTTON, BAR_GHOST)}
               disabled={getDisabled(runningState)}
               onClick={() => setOpen(true)}
+              // The warning state is carried by a badge drawn over the corner of this button,
+              // which is colour and position and nothing else. Folding it into the name is what
+              // makes the one condition this control reports reachable without seeing it.
+              aria-label={
+                audioInputDeviceNotFound
+                  ? 'Audio options - the selected microphone was not found'
+                  : 'Audio options'
+              }
             >
-              <Mic className="h-4 w-4" />
+              <Mic className="h-4 w-4" aria-hidden="true" />
             </Button>
           </TooltipTrigger>
           <TooltipContent>
@@ -84,6 +92,7 @@ export function AudioGroup({
         {audioInputDeviceNotFound && (
           <Badge
             variant="destructive"
+            aria-hidden="true"
             className="absolute -bottom-1 -right-1 h-4 min-w-4 rounded-full px-1 flex items-center justify-center text-[10px] border"
           >
             !

--- a/src/renderer/components/custom/control-panel/audio-group.tsx
+++ b/src/renderer/components/custom/control-panel/audio-group.tsx
@@ -139,8 +139,12 @@ export function AudioGroup({
             <label id="audio-input-label" className="text-xs text-muted-foreground mb-1 block">
               Microphone
             </label>
+            {/* `|| undefined` keeps the pre-existing binding exactly as it was. Radix reserves
+                the empty string for clearing a selection, and the hook reports an unset device as
+                `''` rather than as undefined, so passing it straight through would hand Select a
+                value it treats specially rather than the "nothing chosen yet" it means here. */}
             <Select
-              value={deviceName}
+              value={deviceName || undefined}
               disabled={switching}
               onValueChange={(v) => void setDevice(v)}
             >

--- a/src/renderer/components/custom/control-panel/audio-group.tsx
+++ b/src/renderer/components/custom/control-panel/audio-group.tsx
@@ -1,6 +1,6 @@
 import { DialogDescription } from '@radix-ui/react-dialog';
 import { Mic } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -40,12 +40,27 @@ export function AudioGroup({
     return true;
   });
 
-  // If no audio input device is selected but there are available devices, select the first one by default
-  if ((config?.audioInputDeviceName ?? '') === '') {
-    if (usableAudioInputDevices.length > 0) {
-      updateConfig({ audioInputDeviceName: usableAudioInputDevices[0].name });
-    }
-  }
+  // First usable device as the default, once. In an effect rather than in the render body: a
+  // store write during render re-enters React mid-commit, and because `updateConfig` rolls the
+  // optimistic value back when the IPC call fails, the condition that triggered it is true again
+  // on the very next render - a failed write repeated for every frame, each one an unhandled
+  // rejection. `pickedDefault` also stops it re-picking after the user clears the selection or
+  // unplugs the chosen device mid-session.
+  const pickedDefault = useRef(false);
+  const firstUsableDeviceName = usableAudioInputDevices[0]?.name;
+
+  useEffect(() => {
+    if (pickedDefault.current) return;
+    if (!config) return; // config not loaded yet; '' here would not mean "unset"
+    if (config.audioInputDeviceName !== '') return;
+    if (!firstUsableDeviceName) return;
+
+    pickedDefault.current = true;
+    updateConfig({ audioInputDeviceName: firstUsableDeviceName }).catch((e) => {
+      pickedDefault.current = false;
+      console.error('Failed to select a default microphone', e);
+    });
+  }, [config, firstUsableDeviceName, updateConfig]);
 
   return (
     <div className="flex items-center">

--- a/src/renderer/components/custom/control-panel/audio-group.tsx
+++ b/src/renderer/components/custom/control-panel/audio-group.tsx
@@ -100,12 +100,18 @@ export function AudioGroup({
 
           {/* Microphone Select */}
           <div className="mb-3">
-            <label className="text-xs text-muted-foreground mb-1 block">Microphone</label>
+            <label id="audio-input-label" className="text-xs text-muted-foreground mb-1 block">
+              Microphone
+            </label>
             <Select
               value={config?.audioInputDeviceName}
-              onValueChange={(v) => updateConfig({ audioInputDeviceName: v })}
+              onValueChange={(v) =>
+                updateConfig({ audioInputDeviceName: v }).catch((e) =>
+                  console.error('Failed to save the selected microphone', e)
+                )
+              }
             >
-              <SelectTrigger className="h-8 w-full text-xs">
+              <SelectTrigger aria-labelledby="audio-input-label" className="h-8 w-full text-xs">
                 <SelectValue placeholder="Select microphone" />
               </SelectTrigger>
               <SelectContent>

--- a/src/renderer/components/custom/control-panel/audio-group.tsx
+++ b/src/renderer/components/custom/control-panel/audio-group.tsx
@@ -1,5 +1,5 @@
 import { DialogDescription } from '@radix-ui/react-dialog';
-import { Mic } from 'lucide-react';
+import { Loader, Mic } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import { Badge } from '@/components/ui/badge';
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/select';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useAppState } from '@/hooks/use-app-state';
+import { useAudioInputDevice } from '@/hooks/use-audio-input-device';
 import { useConfigStore } from '@/hooks/use-config-store';
 import { cn } from '@/lib/utils';
 import { RunningState } from '@/types/app-state';
@@ -27,6 +28,18 @@ interface AudioGroupProps {
   getDisabled: (state: RunningState, disableOnRunning?: boolean) => boolean;
 }
 
+/**
+ * Microphone selection, live mid-interview.
+ *
+ * It used to lock while the assistant ran, which made the one case it is needed for
+ * unreachable: a headset that dies, is unplugged, or was the wrong device to begin with, noticed
+ * only once the interviewer cannot hear the answer. Restarting the assistant to fix it drops the
+ * transcript and the suggestion history with it.
+ *
+ * Unlike the language picker, nothing reconnects. The device is only what feeds the worklet, not
+ * a connection parameter, so the socket and any utterance in flight survive - which is why this
+ * carries no warning about a gap in the transcript, because there is not one.
+ */
 export function AudioGroup({
   audioInputDevices,
   audioInputDeviceNotFound,
@@ -35,6 +48,7 @@ export function AudioGroup({
   const [open, setOpen] = useState(false);
   const { runningState } = useAppState();
   const { config, updateConfig } = useConfigStore();
+  const { deviceName, switching, setDevice } = useAudioInputDevice();
   const usableAudioInputDevices = audioInputDevices.filter((d) => {
     if (d.name.toLowerCase().includes('virtual')) return false;
     return true;
@@ -46,6 +60,10 @@ export function AudioGroup({
   // on the very next render - a failed write repeated for every frame, each one an unhandled
   // rejection. `pickedDefault` also stops it re-picking after the user clears the selection or
   // unplugs the chosen device mid-session.
+  //
+  // Deliberately still `updateConfig` rather than the hook's `setDevice`: this is the store
+  // reaching a valid initial state, not a device change, and routing it through the live swap
+  // would put a spinner on a control the user has not touched.
   const pickedDefault = useRef(false);
   const firstUsableDeviceName = usableAudioInputDevices[0]?.name;
 
@@ -62,6 +80,10 @@ export function AudioGroup({
     });
   }, [config, firstUsableDeviceName, updateConfig]);
 
+  // `false`, so the control locks only through the transient Starting and Stopping states, where
+  // the graph it would rewire is being built or torn down anyway.
+  const disabled = getDisabled(runningState, false);
+
   return (
     <div className="flex items-center">
       <div className="relative">
@@ -71,7 +93,7 @@ export function AudioGroup({
               variant="ghost"
               size="icon"
               className={cn(BAR_ICON_BUTTON, BAR_GHOST)}
-              disabled={getDisabled(runningState)}
+              disabled={disabled}
               onClick={() => setOpen(true)}
               // The warning state is carried by a badge drawn over the corner of this button,
               // which is colour and position and nothing else. Folding it into the name is what
@@ -81,8 +103,13 @@ export function AudioGroup({
                   ? 'Audio options - the selected microphone was not found'
                   : 'Audio options'
               }
+              aria-busy={switching}
             >
-              <Mic className="h-4 w-4" aria-hidden="true" />
+              {switching ? (
+                <Loader className="h-4 w-4 animate-spin" aria-hidden="true" />
+              ) : (
+                <Mic className="h-4 w-4" aria-hidden="true" />
+              )}
             </Button>
           </TooltipTrigger>
           <TooltipContent>
@@ -113,12 +140,9 @@ export function AudioGroup({
               Microphone
             </label>
             <Select
-              value={config?.audioInputDeviceName}
-              onValueChange={(v) =>
-                updateConfig({ audioInputDeviceName: v }).catch((e) =>
-                  console.error('Failed to save the selected microphone', e)
-                )
-              }
+              value={deviceName}
+              disabled={switching}
+              onValueChange={(v) => void setDevice(v)}
             >
               <SelectTrigger aria-labelledby="audio-input-label" className="h-8 w-full text-xs">
                 <SelectValue placeholder="Select microphone" />
@@ -131,6 +155,15 @@ export function AudioGroup({
                 ))}
               </SelectContent>
             </Select>
+            {runningState === RunningState.Running && (
+              // Says what will not happen, which is the question a candidate mid-interview
+              // actually has before touching a control on a live session.
+              <p className="mt-1.5 text-xs text-muted-foreground">
+                {switching
+                  ? 'Switching microphone...'
+                  : 'Takes effect immediately. Transcription keeps running.'}
+              </p>
+            )}
           </div>
         </DialogContent>
       </Dialog>

--- a/src/renderer/components/custom/control-panel/index.tsx
+++ b/src/renderer/components/custom/control-panel/index.tsx
@@ -15,6 +15,7 @@ import { RunningState } from '@/types/app-state';
 import PermissionGateDialog from '../permission-gate-dialog';
 import ZoomControl from '../zoom-control';
 import { AudioGroup } from './audio-group';
+import { LanguageGroup } from './language-group';
 import { LLMGroup } from './llm-group';
 import { MainGroup } from './main-group';
 import { ProfessionalModeGroup } from './professional-mode-group';
@@ -160,13 +161,16 @@ export default function ControlPanel() {
 
         <div className="h-5 w-px bg-border" aria-hidden="true" />
 
-        {/* Inputs and model - both open a dialog, both lock while the assistant runs */}
+        {/* What the session runs on - all three lock while the assistant runs. Language sits
+            here rather than with the presentation toggles because it is an input as much as an
+            output: it picks the speech model before it picks the answer's language. */}
         <div className="flex items-center gap-1">
           <AudioGroup
             audioInputDevices={audioInputDevices ?? []}
             audioInputDeviceNotFound={audioInputDeviceNotFound}
             getDisabled={getDisabled}
           />
+          <LanguageGroup getDisabled={getDisabled} />
           <LLMGroup getDisabled={getDisabled} />
         </div>
 

--- a/src/renderer/components/custom/control-panel/index.tsx
+++ b/src/renderer/components/custom/control-panel/index.tsx
@@ -36,9 +36,23 @@ export default function ControlPanel() {
   const { openConfigurationDialog } = useConfigurationDialog();
   const [permGateOpen, setPermGateOpen] = useState(false);
 
-  const audioInputDevices = useAudioInputDevices();
+  const { devices: audioInputDevices, ready: audioDevicesReady } = useAudioInputDevices();
 
   if (isStealth) return null;
+
+  const selectedAudioInputDeviceName = config?.audioInputDeviceName ?? '';
+
+  // Three states, not two. Until enumerateDevices() has settled the list is empty because
+  // nothing has been asked yet, and a bare `find(...) === undefined` reports the configured
+  // microphone as missing for the first frames after mount - a red badge on a working device,
+  // and a start that is refused if the user is quick. An unset name is not "missing" either:
+  // AudioGroup is picking the default at that moment.
+  const noAudioInputDevices = audioDevicesReady && audioInputDevices.length === 0;
+  const audioInputDeviceNotFound =
+    audioDevicesReady &&
+    audioInputDevices.length > 0 &&
+    selectedAudioInputDeviceName !== '' &&
+    !audioInputDevices.some((d) => d.name === selectedAudioInputDeviceName);
 
   const checkCanStart = () => {
     const checks: { ok: boolean; message: string; onFail?: () => void }[] = [
@@ -62,8 +76,12 @@ export default function ControlPanel() {
         onFail: openConfigurationDialog,
       },
       {
+        ok: !noAudioInputDevices,
+        message: 'No microphone was detected. Connect one and try again.',
+      },
+      {
         ok: !audioInputDeviceNotFound,
-        message: `Audio input device "${config?.audioInputDeviceName}" is not found`,
+        message: `Audio input device "${selectedAudioInputDeviceName}" is not found`,
       },
     ];
 
@@ -139,9 +157,6 @@ export default function ControlPanel() {
   };
   const { onClick, className, icon, label } = stateConfig[runningState];
 
-  const audioInputDeviceNotFound =
-    audioInputDevices?.find((d) => d.name === config?.audioInputDeviceName) === undefined;
-
   const getDisabled = (state: RunningState, disableOnRunning: boolean = true): boolean => {
     if (disableOnRunning && state === RunningState.Running) return true;
     return state === RunningState.Starting || state === RunningState.Stopping;
@@ -166,7 +181,7 @@ export default function ControlPanel() {
             output: it picks the speech model before it picks the answer's language. */}
         <div className="flex items-center gap-1">
           <AudioGroup
-            audioInputDevices={audioInputDevices ?? []}
+            audioInputDevices={audioInputDevices}
             audioInputDeviceNotFound={audioInputDeviceNotFound}
             getDisabled={getDisabled}
           />

--- a/src/renderer/components/custom/control-panel/index.tsx
+++ b/src/renderer/components/custom/control-panel/index.tsx
@@ -179,7 +179,9 @@ export default function ControlPanel() {
 
         <div className="h-5 w-px bg-border" aria-hidden="true" />
 
-        {/* What the session runs on - all three lock while the assistant runs. Language sits
+        {/* What the session runs on. Only the model locks while the assistant runs; audio and
+            language stay live, because both are things an interview can get wrong in progress
+            and neither can be fixed by restarting without losing the transcript. Language sits
             here rather than with the presentation toggles because it is an input as much as an
             output: it picks the speech model before it picks the answer's language. */}
         <div className="flex items-center gap-1">

--- a/src/renderer/components/custom/control-panel/index.tsx
+++ b/src/renderer/components/custom/control-panel/index.tsx
@@ -99,9 +99,12 @@ export default function ControlPanel() {
     try {
       await startAssistant();
     } catch (error) {
+      // No stopAssistant() here. startAssistant's own catch has already torn both services down
+      // and put runningState back to Idle; calling it again only walks the button through a
+      // three-second "Stopping" for a session that never started, and its own failure would
+      // land here as an unhandled rejection.
       console.error('Failed to start assistant:', error);
       toast.error(error instanceof Error ? error.message : 'Failed to start assistant');
-      await stopAssistant();
     }
   };
 

--- a/src/renderer/components/custom/control-panel/language-group.tsx
+++ b/src/renderer/components/custom/control-panel/language-group.tsx
@@ -81,34 +81,45 @@ export function LanguageGroup({ getDisabled }: LanguageGroupProps) {
         {/* Opens upward: the menu is portalled into the overflow-hidden <main> from main-frame
             and the control panel is the bottom-most thing in it, so a downward menu is clipped
             rather than flipped. */}
-        <DropdownMenuContent align="start" side="top" className="w-56">
+        {/* Capped and scrollable because the list is 28 long, not the 6 it was built for. The
+            menu opens upward from the bottom-most control, so an uncapped list is not merely
+            tall - it runs off the top of the window and the first entries become unreachable. */}
+        <DropdownMenuContent
+          align="start"
+          side="top"
+          className="flex max-h-[min(60vh,20rem)] w-56 flex-col"
+        >
           <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
             Interview language
           </DropdownMenuLabel>
           <DropdownMenuSeparator />
-          {LANGUAGES.map((item) => {
-            const selected = item.code === language;
-            return (
-              <DropdownMenuItem
-                key={item.code}
-                onClick={() => void setLanguage(item.code)}
-                className="gap-2"
-              >
-                {/* The check occupies its own fixed column rather than being conditionally
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            {LANGUAGES.map((item) => {
+              const selected = item.code === language;
+              return (
+                <DropdownMenuItem
+                  key={item.code}
+                  onClick={() => void setLanguage(item.code)}
+                  className="gap-2"
+                >
+                  {/* The check occupies its own fixed column rather than being conditionally
                     rendered, so the labels do not shift by 16px as the selection moves. */}
-                <Check
-                  className={cn('h-4 w-4 shrink-0', selected ? 'opacity-100' : 'opacity-0')}
-                  aria-hidden="true"
-                />
-                <span className={cn('flex-1', selected && 'font-medium')}>{item.nativeName}</span>
-                {/* The English name earns its place for the reverse lookup: a user who has not
+                  <Check
+                    className={cn('h-4 w-4 shrink-0', selected ? 'opacity-100' : 'opacity-0')}
+                    aria-hidden="true"
+                  />
+                  <span dir="auto" className={cn('flex-1', selected && 'font-medium')}>
+                    {item.nativeName}
+                  </span>
+                  {/* The English name earns its place for the reverse lookup: a user who has not
                     yet found their language scans this column, not the endonyms. */}
-                {item.nativeName !== item.name && (
-                  <span className="text-xs text-muted-foreground">{item.name}</span>
-                )}
-              </DropdownMenuItem>
-            );
-          })}
+                  {item.nativeName !== item.name && (
+                    <span className="text-xs text-muted-foreground">{item.name}</span>
+                  )}
+                </DropdownMenuItem>
+              );
+            })}
+          </div>
           {runningState === RunningState.Running && (
             <>
               <DropdownMenuSeparator />

--- a/src/renderer/components/custom/control-panel/language-group.tsx
+++ b/src/renderer/components/custom/control-panel/language-group.tsx
@@ -1,0 +1,126 @@
+import { Check, Languages, Loader } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useAppState } from '@/hooks/use-app-state';
+import { useInterviewLanguage } from '@/hooks/use-interview-language';
+import { cn } from '@/lib/utils';
+import { RunningState } from '@/types/app-state';
+import { LANGUAGES } from '@/types/language';
+
+import { BAR_GHOST } from './bar';
+
+interface LanguageGroupProps {
+  getDisabled: (state: RunningState, disableOnRunning?: boolean) => boolean;
+}
+
+/**
+ * Interview language: which speech model transcribes, and what language answers come back in.
+ *
+ * Live mid-interview, and deliberately so - an interview that switches language is the case this
+ * control exists for, and it is not one the candidate can prepare for by restarting. It takes
+ * `getDisabled(state, false)`, which locks it only through the transient Starting and Stopping
+ * states, where the sockets it would reconnect are being opened or torn down anyway.
+ *
+ * The switch is not instant, and the button says so: the ASR carries its language as a connection
+ * parameter, so both channels reconnect. Suggestions need no wait, since the next request reads
+ * the new setting as it is built.
+ *
+ * The trigger carries the code as well as the icon. A globe alone is only useful to someone who
+ * already knows what it is set to, and the one thing this control has to answer at a glance is
+ * exactly that - a candidate whose interview has just switched language has seconds.
+ */
+export function LanguageGroup({ getDisabled }: LanguageGroupProps) {
+  const { runningState } = useAppState();
+  const { language, option, switching, setLanguage } = useInterviewLanguage();
+  const disabled = getDisabled(runningState, false) || switching;
+
+  return (
+    <div className="flex items-center">
+      {/* Non-modal for the same reason as the export menu: a modal menu locks body pointer
+          events, and picking an item unmounts the menu before it releases the lock. */}
+      <DropdownMenu modal={false}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                // BAR_ICON_BUTTON's height and radius, but not its fixed 32px width: the code
+                // beside the icon is the point, and the row's rhythm is carried by the shared
+                // height, not by every control being square.
+                className={cn('h-8 gap-1.5 rounded-lg px-2', BAR_GHOST)}
+                disabled={disabled}
+                aria-label={`Interview language: ${option.name}`}
+                aria-busy={switching}
+              >
+                {switching ? (
+                  <Loader className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Languages className="h-4 w-4" />
+                )}
+                <span className="text-[11px] font-medium tracking-wide">{option.short}</span>
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Interview Language: {option.nativeName}</p>
+            <p className="text-xs text-muted-foreground">
+              {switching ? 'Reconnecting transcription...' : 'Speech recognition and suggestions'}
+            </p>
+          </TooltipContent>
+        </Tooltip>
+        {/* Opens upward: the menu is portalled into the overflow-hidden <main> from main-frame
+            and the control panel is the bottom-most thing in it, so a downward menu is clipped
+            rather than flipped. */}
+        <DropdownMenuContent align="start" side="top" className="w-56">
+          <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+            Interview language
+          </DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          {LANGUAGES.map((item) => {
+            const selected = item.code === language;
+            return (
+              <DropdownMenuItem
+                key={item.code}
+                onClick={() => void setLanguage(item.code)}
+                className="gap-2"
+              >
+                {/* The check occupies its own fixed column rather than being conditionally
+                    rendered, so the labels do not shift by 16px as the selection moves. */}
+                <Check
+                  className={cn('h-4 w-4 shrink-0', selected ? 'opacity-100' : 'opacity-0')}
+                  aria-hidden="true"
+                />
+                <span className={cn('flex-1', selected && 'font-medium')}>{item.nativeName}</span>
+                {/* The English name earns its place for the reverse lookup: a user who has not
+                    yet found their language scans this column, not the endonyms. */}
+                {item.nativeName !== item.name && (
+                  <span className="text-xs text-muted-foreground">{item.name}</span>
+                )}
+              </DropdownMenuItem>
+            );
+          })}
+          {runningState === RunningState.Running && (
+            <>
+              <DropdownMenuSeparator />
+              {/* Says what will happen before it happens: a two-second hole in the transcript
+                  is alarming if it arrives unannounced mid-question. */}
+              <div className="px-2 py-1.5 text-xs text-muted-foreground">
+                Transcription reconnects; the current sentence may be cut short.
+              </div>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/src/renderer/components/custom/control-panel/llm-group.tsx
+++ b/src/renderer/components/custom/control-panel/llm-group.tsx
@@ -279,13 +279,17 @@ export function LLMGroup({ getDisabled }: LLMGroupProps) {
           </div>
 
           <div className="grid gap-2">
-            <label className="text-xs text-muted-foreground">LLM Provider</label>
+            {/* A Radix Select trigger is a button, not a form control, so htmlFor does not
+                reach it. id + aria-labelledby is what associates the two. */}
+            <label id="llm-provider-label" className="text-xs text-muted-foreground">
+              LLM Provider
+            </label>
             <Select
               value={currentProvider}
               onValueChange={handleProviderChange}
               disabled={isProviderDisabled}
             >
-              <SelectTrigger className="h-8 w-full text-xs">
+              <SelectTrigger aria-labelledby="llm-provider-label" className="h-8 w-full text-xs">
                 <SelectValue placeholder={providerPlaceholder} />
               </SelectTrigger>
               <SelectContent>
@@ -299,9 +303,14 @@ export function LLMGroup({ getDisabled }: LLMGroupProps) {
           </div>
 
           <div className="grid gap-2">
-            <label className="text-xs text-muted-foreground">API Key</label>
+            <label htmlFor="llm-api-key" className="text-xs text-muted-foreground">
+              API Key
+            </label>
             <Input
+              id="llm-api-key"
+              name="llm-api-key"
               type="password"
+              autoComplete="off"
               value={apiKey}
               onChange={(e) => setApiKey(e.target.value)}
               placeholder="Enter API key"
@@ -312,9 +321,11 @@ export function LLMGroup({ getDisabled }: LLMGroupProps) {
           </div>
 
           <div className="grid gap-2">
-            <label className="text-xs text-muted-foreground">Model</label>
+            <label id="llm-model-label" className="text-xs text-muted-foreground">
+              Model
+            </label>
             <Select value={effectiveModel} onValueChange={onModelChange} disabled={isModelDisabled}>
-              <SelectTrigger className="h-8 w-full text-xs">
+              <SelectTrigger aria-labelledby="llm-model-label" className="h-8 w-full text-xs">
                 <SelectValue placeholder={modelPlaceholder} />
               </SelectTrigger>
               <SelectContent>

--- a/src/renderer/components/custom/control-panel/tools-group.tsx
+++ b/src/renderer/components/custom/control-panel/tools-group.tsx
@@ -99,6 +99,7 @@ export function ToolsGroup({ getDisabled }: ToolsGroupProps) {
                     size="sm"
                     variant="outline"
                     className="h-6 w-6 p-0"
+                    aria-label="Open the exported file"
                     onClick={() => electron?.openFile(filePath)}
                   >
                     <FileIcon className="h-3 w-3" />
@@ -112,6 +113,7 @@ export function ToolsGroup({ getDisabled }: ToolsGroupProps) {
                     size="sm"
                     variant="outline"
                     className="h-6 w-6 p-0"
+                    aria-label="Show the exported file in its folder"
                     onClick={() => electron?.showInFolder(filePath)}
                   >
                     <FolderOpenIcon className="h-3 w-3" />
@@ -125,6 +127,7 @@ export function ToolsGroup({ getDisabled }: ToolsGroupProps) {
                     size="sm"
                     variant="ghost"
                     className="h-6 w-6 p-0"
+                    aria-label="Dismiss"
                     onClick={() => toast.dismiss(toastId)}
                   >
                     <XIcon className="h-3 w-3" />
@@ -156,6 +159,7 @@ export function ToolsGroup({ getDisabled }: ToolsGroupProps) {
             size="sm"
             className={cn(BAR_ICON_BUTTON, transcriptVisible ? BAR_ACTIVE : BAR_GHOST)}
             aria-pressed={transcriptVisible}
+            aria-label={transcriptVisible ? 'Hide transcription' : 'Show transcription'}
           >
             {transcriptVisible ? (
               <Captions className="h-4 w-4" />
@@ -179,6 +183,8 @@ export function ToolsGroup({ getDisabled }: ToolsGroupProps) {
             size="sm"
             className={cn(BAR_ICON_BUTTON, BAR_GHOST)}
             disabled={getDisabled(runningState) || exporting || clearing}
+            aria-label="Clear the interview"
+            aria-busy={clearing}
           >
             {clearing ? (
               <Loader className="h-4 w-4 animate-spin" />
@@ -202,6 +208,8 @@ export function ToolsGroup({ getDisabled }: ToolsGroupProps) {
                 size="sm"
                 className={cn(BAR_ICON_BUTTON, BAR_GHOST)}
                 disabled={getDisabled(runningState) || exporting}
+                aria-label="Export the interview"
+                aria-busy={exporting}
               >
                 {exporting ? (
                   <Loader className="h-4 w-4 animate-spin" />

--- a/src/renderer/components/custom/control-panel/tools-group.tsx
+++ b/src/renderer/components/custom/control-panel/tools-group.tsx
@@ -37,7 +37,7 @@ interface ToolsGroupProps {
 }
 
 export function ToolsGroup({ getDisabled }: ToolsGroupProps) {
-  const { runningState } = useAppState();
+  const { runningState, appState } = useAppState();
   const { exporting, exportTranscript, clearAll, setPlaceholderData } = useTools();
   const { visible: transcriptVisible, toggle: onToggleTranscript } = useTranscriptPanel();
   const [clearing, setClearing] = useState(false);
@@ -57,7 +57,22 @@ export function ToolsGroup({ getDisabled }: ToolsGroupProps) {
     }
   };
 
+  // Nothing recorded yet. Checked here as well as in the service, and this is the copy the user
+  // actually reads: an error thrown out of an ipcMain handler reaches the renderer wrapped in
+  // Electron's "Error invoking remote method 'tools:export-transcript'" prefix, which is not a
+  // sentence to put in front of someone. The service keeps its own guard because it is what
+  // stops the billed summarize call, and this state can be stale by a broadcast.
+  const nothingToExport =
+    (appState?.transcripts?.length ?? 0) === 0 && (appState?.liveSuggestions?.length ?? 0) === 0;
+
   const onExportTranscript = async (format: ExportFormat) => {
+    if (nothingToExport) {
+      toast.error('There is nothing to export yet', {
+        description: 'Run an interview first, then export the transcript and suggestions.',
+      });
+      return;
+    }
+
     try {
       const filePath = await exportTranscript(format);
       if (!filePath) return;
@@ -124,7 +139,9 @@ export function ToolsGroup({ getDisabled }: ToolsGroupProps) {
       );
     } catch (error) {
       console.error(error);
-      toast.error('Failed to export interview');
+      // The message when there is nothing to export names the reason, and a generic "failed"
+      // over it would send the user looking for a fault that is not there.
+      toast.error(error instanceof Error ? error.message : 'Failed to export interview');
     }
   };
 

--- a/src/renderer/components/custom/documentation-dialog.tsx
+++ b/src/renderer/components/custom/documentation-dialog.tsx
@@ -94,13 +94,38 @@ export default function DocumentationDialog({ open, onOpenChange }: Documentatio
                 <p className="text-sm text-muted-foreground">
                   The language button on the control bar sets the language of the whole session:
                   which speech model transcribes the call, what language suggestions are written in,
-                  and the language of the exported report.{' '}
-                  {LANGUAGES.map((l) => l.nativeName).join(', ')} are supported.
+                  and the language of the exported report.
+                </p>
+                {/* A list rather than a sentence: at 28 entries the run-on paragraph this used to
+                    be could not be scanned for one's own language, which is the only question a
+                    reader opens this section with. Derived from LANGUAGES so it cannot drift. */}
+                <p className="mt-2 text-sm text-muted-foreground">
+                  {LANGUAGES.length} languages are supported:{' '}
+                  <span dir="auto">{LANGUAGES.map((l) => l.nativeName).join(' · ')}</span>
                 </p>
                 <p className="mt-2 text-sm text-muted-foreground">
                   You can change it mid-interview. Suggestions follow immediately, from the next
                   answer onward. Speech recognition takes a moment longer: it reconnects, so the
                   sentence being spoken at that instant may be cut short in the transcript.
+                </p>
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="microphone">
+              <AccordionTrigger className="text-sm font-semibold">
+                Changing microphone mid-interview
+              </AccordionTrigger>
+              <AccordionContent>
+                <p className="text-sm text-muted-foreground">
+                  The microphone button on the control bar stays available while an interview is
+                  running. If your headset dies, is unplugged, or was the wrong device to begin
+                  with, pick another one there rather than stopping the assistant - stopping it
+                  clears the transcript and the suggestions with it.
+                </p>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  The change takes effect immediately and transcription keeps running, so nothing is
+                  cut short. If the device you pick cannot be opened - unplugged, or in use by
+                  another app - the interview carries on using the previous one and the app says so.
                 </p>
               </AccordionContent>
             </AccordionItem>

--- a/src/renderer/components/custom/documentation-dialog.tsx
+++ b/src/renderer/components/custom/documentation-dialog.tsx
@@ -18,6 +18,7 @@ import {
 import { APP_NAME } from '@/lib/consts';
 import { Hotkey, HOTKEY_GROUPS, HOTKEYS } from '@/lib/hotkeys';
 import { cn } from '@/lib/utils';
+import { LANGUAGES } from '@/types/language';
 
 import ExternalLink from './external-link';
 
@@ -81,6 +82,25 @@ export default function DocumentationDialog({ open, onOpenChange }: Documentatio
                   button to click. Just launch {APP_NAME} again: it does not start a second copy, it
                   brings this window back. Outside stealth mode the usual taskbar button and Dock
                   icon are there.
+                </p>
+              </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="language">
+              <AccordionTrigger className="text-sm font-semibold">
+                Interviewing in another language
+              </AccordionTrigger>
+              <AccordionContent>
+                <p className="text-sm text-muted-foreground">
+                  The language button on the control bar sets the language of the whole session:
+                  which speech model transcribes the call, what language suggestions are written in,
+                  and the language of the exported report.{' '}
+                  {LANGUAGES.map((l) => l.nativeName).join(', ')} are supported.
+                </p>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  You can change it mid-interview. Suggestions follow immediately, from the next
+                  answer onward. Speech recognition takes a moment longer: it reconnects, so the
+                  sentence being spoken at that instant may be cut short in the transcript.
                 </p>
               </AccordionContent>
             </AccordionItem>

--- a/src/renderer/components/custom/input-password.tsx
+++ b/src/renderer/components/custom/input-password.tsx
@@ -28,14 +28,26 @@ export function InputPassword({
         className={`pr-10 ${className}`}
         {...props}
       />
+      {/* The only control in the auth forms with no text of its own. Without a name it is
+          announced as "button", on a field whose value is deliberately unreadable - and
+          aria-pressed is what says which of the two states it is currently in. tabIndex -1
+          keeps it out of the tab order between the password field and the submit button,
+          where it is a stop that a keyboard user working through a form does not want. */}
       <Button
         type="button"
         variant="ghost"
         size="sm"
+        tabIndex={-1}
+        aria-label={showPassword ? 'Hide password' : 'Show password'}
+        aria-pressed={showPassword}
         className="absolute right-0 top-0 h-full px-3 py-2"
         onClick={toggleShowPassword}
       >
-        {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+        {showPassword ? (
+          <EyeOff className="h-4 w-4" aria-hidden="true" />
+        ) : (
+          <Eye className="h-4 w-4" aria-hidden="true" />
+        )}
       </Button>
     </div>
   );

--- a/src/renderer/components/custom/panels/action-suggestions-panel.tsx
+++ b/src/renderer/components/custom/panels/action-suggestions-panel.tsx
@@ -4,16 +4,11 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Card } from '@/components/ui/card';
 import { useConfigStore } from '@/hooks/use-config-store';
 import useIsStealthMode from '@/hooks/use-is-stealth-mode';
-import { newestTimestamp } from '@/lib/suggestions';
+import { newestTimestamp, truncateMiddle } from '@/lib/suggestions';
 import { type ActionSuggestion, SuggestionState } from '@/types/suggestion';
 
 // when a question is too long we truncate it in the middle to keep the UI compact
 const MAX_QUESTION_LENGTH = 256;
-function truncateMiddle(text: string, maxLen: number): string {
-  if (text.length <= maxLen) return text;
-  const half = Math.floor((maxLen - 3) / 2);
-  return text.slice(0, half) + ' ... ... ... ' + text.slice(text.length - (maxLen - 3 - half));
-}
 
 import { Button } from '../../ui/button';
 import { Checkbox } from '../../ui/checkbox';

--- a/src/renderer/components/custom/panels/live-suggestions-panel.tsx
+++ b/src/renderer/components/custom/panels/live-suggestions-panel.tsx
@@ -5,15 +5,14 @@ import { useConfigStore } from '@/hooks/use-config-store';
 
 const MAX_QUESTION_LENGTH = 256;
 
-function truncateMiddle(text: string, maxLen: number): string {
-  if (text.length <= maxLen) return text;
-  const half = Math.floor((maxLen - 3) / 2);
-  return text.slice(0, half) + ' ... ... ... ' + text.slice(text.length - (maxLen - 3 - half));
-}
-
 import { Card } from '@/components/ui/card';
 import useIsStealthMode from '@/hooks/use-is-stealth-mode';
-import { newestTimestamp, stripDanglingEmphasis, withHardBreaks } from '@/lib/suggestions';
+import {
+  newestTimestamp,
+  stripDanglingEmphasis,
+  truncateMiddle,
+  withHardBreaks,
+} from '@/lib/suggestions';
 import { SuggestionMode } from '@/types/llm';
 import { type LiveSuggestion, SuggestionState } from '@/types/suggestion';
 

--- a/src/renderer/hooks/use-assistant-service.ts
+++ b/src/renderer/hooks/use-assistant-service.ts
@@ -1,3 +1,4 @@
+import { toast } from 'sonner';
 import { create } from 'zustand';
 
 import { getElectron } from '@/lib/utils';
@@ -55,10 +56,7 @@ export const useAssistantService = create<AssistantService>((set) => ({
       // succeeded, and leaving it active while runningState goes back to Idle strands the app
       // in a state where transcripts keep flowing (so live suggestions still fire) but every
       // action-suggestion hotkey refuses forever, because those gate on runningState.
-      await Promise.allSettled([
-        liveTranscriptionService.stop(),
-        electron.transcription.stop(),
-      ]);
+      await Promise.allSettled([liveTranscriptionService.stop(), electron.transcription.stop()]);
 
       // Reset state to Idle so the button doesn't stay stuck on "Starting..."
       electron.appState.update({ runningState: RunningState.Idle });
@@ -70,37 +68,50 @@ export const useAssistantService = create<AssistantService>((set) => ({
   },
 
   stopAssistant: async () => {
+    set({ error: null });
+
+    const electron = getElectron();
+    if (!electron) {
+      const message = 'Electron API not available';
+      set({ error: message });
+      throw new Error(message);
+    }
+
+    electron.appState.update({ runningState: RunningState.Stopping });
+
     try {
-      set({ error: null });
-
-      const electron = getElectron();
-      if (!electron) {
-        throw new Error('Electron API not available');
-      }
-      electron.appState.update({ runningState: RunningState.Stopping });
-
-      // Stop assistant services
-      await Promise.all([
+      // allSettled, not all: `all` rejects on the first teardown that throws and abandons the
+      // rest, so one failing service left the other three running. Every one of these is a
+      // best-effort release of something that must not outlive the session.
+      const results = await Promise.allSettled([
         liveTranscriptionService.stop(),
         electron.transcription.stop(),
         electron.liveSuggestion.stop(),
         electron.actionSuggestion.stop(),
       ]);
 
+      const failures = results.filter((r) => r.status === 'rejected');
+      if (failures.length > 0) {
+        console.error('Stop assistant: some services failed to stop', failures);
+        set({ error: 'Some services did not stop cleanly' });
+        // Said out loud rather than left in store state nothing renders. The session is over
+        // either way, but a channel that refused to close is the difference between "stopped"
+        // and "still listening", and that is not something to discover from a log file.
+        toast.warning('The assistant stopped, but not everything shut down cleanly', {
+          description: 'Restart the app if transcription or suggestions keep arriving.',
+        });
+      }
+
       electron.setStealth(false); // Ensure stealth mode is turned off when stopping assistant
 
       // Sleep 3 seconds to ensure the assistant has fully stopped before allowing start actions
       await new Promise((resolve) => setTimeout(resolve, 3000));
-
-      // Update running state to Idle after successful stop
+    } finally {
+      // Unconditional, and the reason this is a `finally`. Every control on the bar is disabled
+      // while the state is Stopping, Stop included, so a throw on the way out used to leave the
+      // app permanently frozen mid-teardown with no way back other than restarting it. Whatever
+      // happened above, the session is over and the UI has to be able to say so.
       electron.appState.update({ runningState: RunningState.Idle });
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Failed to stop assistant';
-      set({
-        error: errorMessage,
-      });
-      console.error('Stop assistant error:', error);
-      throw error;
     }
   },
 

--- a/src/renderer/hooks/use-assistant-service.ts
+++ b/src/renderer/hooks/use-assistant-service.ts
@@ -38,8 +38,9 @@ export const useAssistantService = create<AssistantService>((set) => ({
 
       // Start transcription services
       await electron.transcription.start();
-      // The language the sockets open on. It can change mid-session after this, but only
-      // through useInterviewLanguage, which reconnects them - nothing else reads it again.
+      // What the session opens on. Both of these can change mid-session after this, and neither
+      // is re-read here: useInterviewLanguage reconnects the sockets for a language change, and
+      // useAudioInputDevice swaps the microphone's stream in place for a device change.
       await liveTranscriptionService.start(
         config?.audioInputDeviceName ?? '',
         config?.sessionToken ?? '',

--- a/src/renderer/hooks/use-assistant-service.ts
+++ b/src/renderer/hooks/use-assistant-service.ts
@@ -3,6 +3,7 @@ import { create } from 'zustand';
 import { getElectron } from '@/lib/utils';
 import { liveTranscriptionService } from '@/services/live-transcription.service';
 import { RunningState } from '@/types/app-state';
+import { DEFAULT_LANGUAGE } from '@/types/language';
 
 import { useConfigStore } from './use-config-store';
 
@@ -36,9 +37,12 @@ export const useAssistantService = create<AssistantService>((set) => ({
 
       // Start transcription services
       await electron.transcription.start();
+      // The language the sockets open on. It can change mid-session after this, but only
+      // through useInterviewLanguage, which reconnects them - nothing else reads it again.
       await liveTranscriptionService.start(
         config?.audioInputDeviceName ?? '',
-        config?.sessionToken ?? ''
+        config?.sessionToken ?? '',
+        config?.language ?? DEFAULT_LANGUAGE
       );
 
       // Sleep 3 seconds to ensure the assistant has fully started before allowing stop actions

--- a/src/renderer/hooks/use-audio-devices.ts
+++ b/src/renderer/hooks/use-audio-devices.ts
@@ -1,6 +1,6 @@
 import { type AudioDevice } from '@/types/audio-device';
 
-import { useMediaDevices } from './use-media-devices';
+import { type MediaDevicesResult, useMediaDevices } from './use-media-devices';
 
 function filterAudioDevices(devices: MediaDeviceInfo[], deviceType: string): AudioDevice[] {
   return devices
@@ -14,6 +14,6 @@ function filterAudioDevices(devices: MediaDeviceInfo[], deviceType: string): Aud
     }));
 }
 
-export function useAudioInputDevices(): AudioDevice[] {
+export function useAudioInputDevices(): MediaDevicesResult<AudioDevice> {
   return useMediaDevices('audioinput', (devices) => filterAudioDevices(devices, 'Input'));
 }

--- a/src/renderer/hooks/use-audio-input-device.ts
+++ b/src/renderer/hooks/use-audio-input-device.ts
@@ -1,0 +1,55 @@
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+
+import { liveTranscriptionService } from '@/services/live-transcription.service';
+
+import { useConfigStore } from './use-config-store';
+
+/**
+ * The selected microphone, plus a setter that persists it and applies it to a running session.
+ *
+ * Shaped like `useInterviewLanguage`, and different from it in the one way that matters: the
+ * input device is not a connection parameter, so nothing reconnects. The socket, the provider
+ * session and any utterance in flight all survive a swap, which is why this control can stay
+ * live during a call without warning the user that the transcript is about to gap.
+ *
+ * Persisted first, applied second, and never rolled back on failure. A failed swap leaves the
+ * session on the microphone it already had - the audio does not stop - so reverting the setting
+ * would only leave the user with no route to the device they picked, while leaving it set means
+ * stopping and starting the assistant reaches it.
+ */
+export function useAudioInputDevice() {
+  const { config } = useConfigStore();
+  const [switching, setSwitching] = useState(false);
+  const deviceName = config?.audioInputDeviceName ?? '';
+
+  const setDevice = useCallback(async (name: string) => {
+    const { config: current, updateConfig } = useConfigStore.getState();
+    if (current?.audioInputDeviceName === name) return;
+
+    try {
+      await updateConfig({ audioInputDeviceName: name });
+    } catch (e) {
+      console.error('Failed to save the selected microphone', e);
+      toast.error('Failed to save the selected microphone');
+      return;
+    }
+
+    setSwitching(true);
+    try {
+      await liveTranscriptionService.setAudioInputDevice(name);
+    } catch (e) {
+      // Unplugged, held by another app, or refused by permissions. The session is still running
+      // on the previous device, so this is a warning rather than an error, and it says which
+      // state the user is actually in - the setting took, the audio did not move.
+      console.error('Failed to switch microphone', e);
+      toast.warning('Saved, but the interview is still using the previous microphone', {
+        description: 'Check the device is connected, then stop and start the assistant.',
+      });
+    } finally {
+      setSwitching(false);
+    }
+  }, []);
+
+  return { deviceName, switching, setDevice };
+}

--- a/src/renderer/hooks/use-interview-language.ts
+++ b/src/renderer/hooks/use-interview-language.ts
@@ -1,0 +1,56 @@
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+
+import { liveTranscriptionService } from '@/services/live-transcription.service';
+import { getLanguageOption, type Language } from '@/types/language';
+
+import { useConfigStore } from './use-config-store';
+
+/**
+ * The interview language, plus a setter that persists it and applies it to a running session.
+ *
+ * Resolved through `getLanguageOption` rather than read raw: the stored value is whatever some
+ * build wrote to disk, and a code this build does not know would otherwise render as a blank
+ * trigger on the control bar.
+ *
+ * The two halves of the setting move at different speeds, and the setter is where that is
+ * reconciled. Suggestions need nothing: each request reads the config store as it is built, so
+ * the next one already follows the new language. The ASR sockets carry theirs as a connection
+ * parameter, so they have to be torn down and re-opened - which takes a second or two and is why
+ * `switching` exists rather than the change simply appearing to be instant.
+ */
+export function useInterviewLanguage() {
+  const { config } = useConfigStore();
+  const [switching, setSwitching] = useState(false);
+  const option = getLanguageOption(config?.language);
+
+  const setLanguage = useCallback(async (language: Language) => {
+    const { config: current, updateConfig } = useConfigStore.getState();
+    if (current?.language === language) return;
+
+    try {
+      await updateConfig({ language });
+    } catch (e) {
+      console.error('Failed to save interview language', e);
+      toast.error('Failed to save interview language');
+      return;
+    }
+
+    // Persisted first, reconnected second. If the reconnect fails the setting still stands, so
+    // stopping and starting the assistant recovers; rolling the setting back on a failed
+    // reconnect would leave the user with no way to reach the language they picked.
+    setSwitching(true);
+    try {
+      await liveTranscriptionService.setLanguage(language);
+    } catch (e) {
+      console.error('Failed to switch transcription language', e);
+      toast.error('Suggestions switched language, but transcription could not reconnect', {
+        description: 'Stop and start the assistant to apply it.',
+      });
+    } finally {
+      setSwitching(false);
+    }
+  }, []);
+
+  return { language: option.code, option, switching, setLanguage };
+}

--- a/src/renderer/hooks/use-interview-language.ts
+++ b/src/renderer/hooks/use-interview-language.ts
@@ -36,16 +36,16 @@ export function useInterviewLanguage() {
       return;
     }
 
-    // Persisted first, reconnected second. If the reconnect fails the setting still stands, so
-    // stopping and starting the assistant recovers; rolling the setting back on a failed
-    // reconnect would leave the user with no way to reach the language they picked.
+    // Persisted first, reconnected second. If the reconnect fails the setting still stands and
+    // the channel keeps retrying on it; rolling the setting back would leave the user with no
+    // way to reach the language they picked.
     setSwitching(true);
     try {
       await liveTranscriptionService.setLanguage(language);
     } catch (e) {
       console.error('Failed to switch transcription language', e);
-      toast.error('Suggestions switched language, but transcription could not reconnect', {
-        description: 'Stop and start the assistant to apply it.',
+      toast.warning('Suggestions switched language; transcription is still reconnecting', {
+        description: 'It keeps retrying. Stop and start the assistant if it does not come back.',
       });
     } finally {
       setSwitching(false);

--- a/src/renderer/hooks/use-media-devices.ts
+++ b/src/renderer/hooks/use-media-devices.ts
@@ -1,24 +1,45 @@
 import { useEffect, useState } from 'react';
 
+export interface MediaDevicesResult<T> {
+  devices: T[];
+  /**
+   * False until the first `enumerateDevices()` call has settled.
+   *
+   * An empty list means two different things - "not asked yet" and "this machine has none" -
+   * and callers that cannot tell them apart report the second one during the first few frames
+   * after mount. Every consumer that renders a warning or blocks an action needs the difference.
+   */
+  ready: boolean;
+}
+
 export function useMediaDevices<T>(
   kind: MediaDeviceKind,
   transform: (devices: MediaDeviceInfo[]) => T[]
-): T[] {
-  const [result, setResult] = useState<T[]>([]);
+): MediaDevicesResult<T> {
+  const [result, setResult] = useState<MediaDevicesResult<T>>({ devices: [], ready: false });
 
   useEffect(() => {
+    let cancelled = false;
+
     async function fetch() {
+      let devices: T[] = [];
       try {
         const all = await navigator.mediaDevices.enumerateDevices();
-        setResult(transform(all.filter((d) => d.kind === kind)));
+        devices = transform(all.filter((d) => d.kind === kind));
       } catch {
-        // enumerateDevices is not available in all environments
+        // enumerateDevices is not available in all environments. Still marked ready: the answer
+        // is "none available", and leaving it pending forever hides that from every caller.
       }
+      if (cancelled) return;
+      setResult({ devices, ready: true });
     }
 
     fetch();
     navigator.mediaDevices.addEventListener('devicechange', fetch);
-    return () => navigator.mediaDevices.removeEventListener('devicechange', fetch);
+    return () => {
+      cancelled = true;
+      navigator.mediaDevices.removeEventListener('devicechange', fetch);
+    };
   }, [kind]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return result;

--- a/src/renderer/lib/suggestions.ts
+++ b/src/renderer/lib/suggestions.ts
@@ -56,3 +56,27 @@ export function stripDanglingEmphasis(text: string): string {
 
   return out;
 }
+
+/**
+ * Shorten a question to `maxLen` characters, dropping the middle rather than the tail.
+ *
+ * The opening words say what the interviewer asked and the closing ones usually carry the actual
+ * ask, so a tail truncation loses the half that matters. The separator is counted against the
+ * budget: both panels used to subtract three characters for it and then splice in thirteen, so
+ * the "256 character" cap produced 266-character lines and the caller's arithmetic was wrong
+ * wherever it was reused.
+ */
+const TRUNCATE_SEPARATOR = ' ... ';
+
+export function truncateMiddle(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  // Nothing meaningful survives once the separator eats the budget; fall back to a plain head cut.
+  if (maxLen <= TRUNCATE_SEPARATOR.length) return text.slice(0, Math.max(0, maxLen));
+
+  const keep = maxLen - TRUNCATE_SEPARATOR.length;
+  const head = Math.ceil(keep / 2);
+  const tail = keep - head;
+  return (
+    text.slice(0, head) + TRUNCATE_SEPARATOR + (tail > 0 ? text.slice(text.length - tail) : '')
+  );
+}

--- a/src/renderer/pages/auth/forgot-password.tsx
+++ b/src/renderer/pages/auth/forgot-password.tsx
@@ -109,9 +109,14 @@ export default function ForgotPasswordPage() {
         {step === 'email' && (
           <form onSubmit={submitEmail} className="space-y-4">
             <div>
-              <label className="text-sm block mb-1">Email</label>
+              <label htmlFor="reset-email" className="text-sm block mb-1">
+                Email
+              </label>
               <Input
+                id="reset-email"
+                name="email"
                 type="email"
+                autoComplete="username"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 maxLength={254}
@@ -119,7 +124,11 @@ export default function ForgotPasswordPage() {
               />
             </div>
 
-            {error && <div className="text-sm text-red-600">{error}</div>}
+            {error && (
+              <div role="alert" className="text-sm text-destructive">
+                {error}
+              </div>
+            )}
 
             <Button type="submit" disabled={loading} className="w-full">
               {loading ? 'Sending…' : 'Send reset code'}
@@ -136,15 +145,29 @@ export default function ForgotPasswordPage() {
         {step === 'code' && (
           <form onSubmit={submitCode} className="space-y-4">
             <div>
-              <label className="text-sm block mb-1">Reset code</label>
+              <label htmlFor="reset-code" className="text-sm block mb-1">
+                Reset code
+              </label>
               <p className="text-sm text-muted-foreground mb-2">
                 If an account exists for {email}, we sent a reset code to it. Paste the code below.
                 It can only be used once, and the email says when it expires.
               </p>
-              <Textarea value={code} onChange={(e) => setCode(e.target.value)} rows={4} required />
+              <Textarea
+                id="reset-code"
+                name="code"
+                autoComplete="one-time-code"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                rows={4}
+                required
+              />
             </div>
 
-            {error && <div className="text-sm text-red-600">{error}</div>}
+            {error && (
+              <div role="alert" className="text-sm text-destructive">
+                {error}
+              </div>
+            )}
 
             <Button type="submit" disabled={loading} className="w-full">
               {loading ? 'Verifying…' : 'Verify'}
@@ -180,8 +203,13 @@ export default function ForgotPasswordPage() {
             </p>
 
             <div>
-              <label className="text-sm block mb-1">New password</label>
+              <label htmlFor="reset-password" className="text-sm block mb-1">
+                New password
+              </label>
               <InputPassword
+                id="reset-password"
+                name="new-password"
+                autoComplete="new-password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 maxLength={128}
@@ -190,8 +218,13 @@ export default function ForgotPasswordPage() {
             </div>
 
             <div>
-              <label className="text-sm block mb-1">Confirm new password</label>
+              <label htmlFor="reset-password-confirm" className="text-sm block mb-1">
+                Confirm new password
+              </label>
               <InputPassword
+                id="reset-password-confirm"
+                name="confirm-password"
+                autoComplete="new-password"
                 value={passwordConfirm}
                 onChange={(e) => setPasswordConfirm(e.target.value)}
                 maxLength={128}
@@ -199,7 +232,11 @@ export default function ForgotPasswordPage() {
               />
             </div>
 
-            {error && <div className="text-sm text-red-600">{error}</div>}
+            {error && (
+              <div role="alert" className="text-sm text-destructive">
+                {error}
+              </div>
+            )}
 
             <Button type="submit" disabled={loading || succeeded} className="w-full">
               {loading ? 'Saving…' : succeeded ? 'Password reset' : 'Set new password'}

--- a/src/renderer/pages/auth/login.tsx
+++ b/src/renderer/pages/auth/login.tsx
@@ -86,9 +86,14 @@ export default function LoginPage() {
       <CardContent>
         <form onSubmit={submit} className="space-y-4">
           <div>
-            <label className="text-sm block mb-1">Email</label>
+            <label htmlFor="login-email" className="text-sm block mb-1">
+              Email
+            </label>
             <Input
+              id="login-email"
+              name="email"
               type="email"
+              autoComplete="username"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               maxLength={254}
@@ -97,8 +102,13 @@ export default function LoginPage() {
           </div>
 
           <div>
-            <label className="text-sm block mb-1">Password</label>
+            <label htmlFor="login-password" className="text-sm block mb-1">
+              Password
+            </label>
             <InputPassword
+              id="login-password"
+              name="password"
+              autoComplete="current-password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               maxLength={128}
@@ -120,7 +130,15 @@ export default function LoginPage() {
             </label>
           </div>
 
-          {error && <div className="text-sm text-red-600">{error}</div>}
+          {/* role=alert: the failure this renders is "Incorrect email or password", which arrives
+              with no other change on screen. Without it a screen reader user submits the form and
+              is told nothing at all. text-destructive rather than red-600 so it stays legible on
+              the dark theme, where a fixed 600-weight red sits close to the card behind it. */}
+          {error && (
+            <div role="alert" className="text-sm text-destructive">
+              {error}
+            </div>
+          )}
 
           <Button type="submit" disabled={loading} className="w-full mt-2">
             {loading ? 'Signing in…' : 'Sign in'}

--- a/src/renderer/pages/auth/signup.tsx
+++ b/src/renderer/pages/auth/signup.tsx
@@ -71,9 +71,14 @@ export default function SignupPage() {
         {step === 'email' && (
           <form onSubmit={submitEmail} className="space-y-4">
             <div>
-              <label className="text-sm block mb-1">Email</label>
+              <label htmlFor="signup-email" className="text-sm block mb-1">
+                Email
+              </label>
               <Input
+                id="signup-email"
+                name="email"
                 type="email"
+                autoComplete="username"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 maxLength={254}
@@ -81,7 +86,11 @@ export default function SignupPage() {
               />
             </div>
 
-            {error && <div className="text-sm text-red-600">{error}</div>}
+            {error && (
+              <div role="alert" className="text-sm text-destructive">
+                {error}
+              </div>
+            )}
 
             <Button type="submit" disabled={loading} className="w-full">
               {loading ? 'Sending…' : 'Send code'}
@@ -98,7 +107,9 @@ export default function SignupPage() {
         {step === 'code' && (
           <form onSubmit={submitCode} className="space-y-4">
             <div>
-              <label className="text-sm block mb-1">Verification code</label>
+              <label htmlFor="signup-code" className="text-sm block mb-1">
+                Verification code
+              </label>
               {/*
                 Conditional, like the reset wizard's step two, because the backend now answers
                 the same whether or not the address already has an account. It sends a code to
@@ -108,13 +119,24 @@ export default function SignupPage() {
               */}
               <p className="text-sm text-muted-foreground mb-2">
                 If {email} does not already have an account, we sent a verification code to it.
-                Paste the code below. If it does, we sent a note explaining how to sign in
-                instead.
+                Paste the code below. If it does, we sent a note explaining how to sign in instead.
               </p>
-              <Textarea value={code} onChange={(e) => setCode(e.target.value)} rows={4} required />
+              <Textarea
+                id="signup-code"
+                name="code"
+                autoComplete="one-time-code"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                rows={4}
+                required
+              />
             </div>
 
-            {error && <div className="text-sm text-red-600">{error}</div>}
+            {error && (
+              <div role="alert" className="text-sm text-destructive">
+                {error}
+              </div>
+            )}
 
             <Button type="submit" disabled={loading} className="w-full">
               {loading ? 'Verifying…' : 'Verify'}
@@ -170,9 +192,14 @@ export default function SignupPage() {
         {step === 'details' && (
           <form onSubmit={submitDetails} className="space-y-4">
             <div>
-              <label className="text-sm block mb-1">Username</label>
+              <label htmlFor="signup-username" className="text-sm block mb-1">
+                Username
+              </label>
               <Input
+                id="signup-username"
+                name="username"
                 type="text"
+                autoComplete="nickname"
                 value={username}
                 onChange={(e) => setUsername(e.target.value)}
                 maxLength={50}
@@ -181,8 +208,13 @@ export default function SignupPage() {
             </div>
 
             <div>
-              <label className="text-sm block mb-1">Password</label>
+              <label htmlFor="signup-password" className="text-sm block mb-1">
+                Password
+              </label>
               <InputPassword
+                id="signup-password"
+                name="new-password"
+                autoComplete="new-password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 maxLength={128}
@@ -191,8 +223,13 @@ export default function SignupPage() {
             </div>
 
             <div>
-              <label className="text-sm block mb-1">Confirm Password</label>
+              <label htmlFor="signup-password-confirm" className="text-sm block mb-1">
+                Confirm Password
+              </label>
               <InputPassword
+                id="signup-password-confirm"
+                name="confirm-password"
+                autoComplete="new-password"
                 value={passwordConfirm}
                 onChange={(e) => setPasswordConfirm(e.target.value)}
                 maxLength={128}
@@ -200,7 +237,11 @@ export default function SignupPage() {
               />
             </div>
 
-            {error && <div className="text-sm text-red-600">{error}</div>}
+            {error && (
+              <div role="alert" className="text-sm text-destructive">
+                {error}
+              </div>
+            )}
 
             <Button type="submit" disabled={loading} className="w-full">
               {loading ? 'Creating…' : 'Create account'}

--- a/src/renderer/pages/main/index.tsx
+++ b/src/renderer/pages/main/index.tsx
@@ -188,11 +188,14 @@ export default function MainPage() {
       .catch(() => {});
   }, [configLoading, appState?.isBackendLive, appState?.isLoggedIn]);
 
-  // Compute available space when page is navigated to
+  // Compute available space when page is navigated to. Deferred a tick so the titlebar, status
+  // and control rows it measures have been laid out, and cleared on unmount so a navigation
+  // away mid-tick does not measure a torn-down tree.
   useEffect(() => {
-    setTimeout(() => {
+    const id = window.setTimeout(() => {
       computeAvailable();
     }, 10);
+    return () => window.clearTimeout(id);
   }, [computeAvailable]);
 
   // compute panel height by subtracting hotkeys/control/video heights from viewport
@@ -225,10 +228,17 @@ export default function MainPage() {
     computeAvailable();
   }, [isStealth, computeAvailable]);
 
-  // Recompute when assistant running state or appState becomes available
+  // Recompute when the assistant's running state changes.
+  //
+  // Keyed on `runningState` alone. `appState` is a fresh object on every push from main, which
+  // during an interview is every streamed suggestion chunk and every ASR partial - several times
+  // a second. Each run does three getBoundingClientRect() calls, so having it in the dependency
+  // list forced a synchronous layout on the renderer for every token that arrived, while the
+  // panel it was measuring had not changed size at all. None of the other inputs to the layout
+  // live on appState; they all have effects of their own above.
   useEffect(() => {
     computeAvailable();
-  }, [appState?.runningState, appState, computeAvailable]);
+  }, [appState?.runningState, computeAvailable]);
 
   // Memoized styles to prevent unnecessary re-renders
   const transcriptStyle = useMemo(
@@ -261,12 +271,13 @@ export default function MainPage() {
   const _redirectedToLogin = useRef(false);
 
   useEffect(() => {
-    if (appState?.isLoggedIn === false && !_redirectedToLogin.current) {
-      _redirectedToLogin.current = true;
-      setTimeout(() => {
-        navigate('/auth/login', { replace: true });
-      }, 500);
-    }
+    if (appState?.isLoggedIn !== false || _redirectedToLogin.current) return;
+
+    _redirectedToLogin.current = true;
+    const id = window.setTimeout(() => {
+      navigate('/auth/login', { replace: true });
+    }, 500);
+    return () => window.clearTimeout(id);
   }, [appState?.isLoggedIn, navigate]);
 
   // Show loading if not logged in (fallback)

--- a/src/renderer/pages/payment/index.tsx
+++ b/src/renderer/pages/payment/index.tsx
@@ -67,8 +67,9 @@ export default function PaymentPage() {
             size="icon-sm"
             onClick={handleBack}
             className="flex items-center shrink-0"
+            aria-label="Back to the interview"
           >
-            <ArrowLeft className="h-4 w-4" />
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           </Button>
           <h1 className="text-sm font-semibold shrink-0">Buy Credits</h1>
           <TabsList className="ml-auto">

--- a/src/renderer/services/live-transcription.service.ts
+++ b/src/renderer/services/live-transcription.service.ts
@@ -73,7 +73,7 @@ class AudioWsStream {
 
   constructor(
     private readonly channel: Channel,
-    private readonly stream: MediaStream,
+    private stream: MediaStream,
     private language: Language,
     private readonly onTranscript: (payload: {
       channel: Channel;
@@ -153,6 +153,35 @@ class AudioWsStream {
       this.ws.close();
     }
     this.ws = null;
+  }
+
+  /**
+   * Point this channel at a different audio source, without reconnecting.
+   *
+   * Unlike the language, the input device is not a connection parameter - it is only what feeds
+   * the worklet - so the socket, the provider session and any utterance in flight all survive.
+   * That is why this costs no gap in the transcript where `setLanguage` costs a second or two,
+   * and why it is safe to leave the control live during a call.
+   *
+   * The caller owns stopping the old stream, and must do it *after* this resolves: the tracks
+   * are still feeding the graph until the source below is replaced.
+   */
+  async setStream(stream: MediaStream): Promise<void> {
+    // No graph yet: start() has not run, or stop() tore it down. Recording the stream is enough,
+    // since start() reads the field.
+    if (!this.ctx || !this.workletNode) {
+      this.stream = stream;
+      return;
+    }
+
+    this.source?.disconnect();
+    this.stream = stream;
+
+    // Built on the existing AudioContext on purpose. Its sampleRate is fixed at construction and
+    // `convertTo16kPcm` reads it, so making a new context here would silently resample against
+    // the wrong rate; `createMediaStreamSource` handles a device that runs at another rate.
+    this.source = this.ctx.createMediaStreamSource(stream);
+    this.source.connect(this.workletNode);
   }
 
   /**
@@ -362,6 +391,10 @@ class LiveTranscriptionService {
   private loopbackStream: MediaStream | null = null;
   private channels: AudioWsStream[] = [];
 
+  // Held separately from `channels` because the microphone is the only one a device change can
+  // move: ch_0 is loopback, captured from the call rather than from a device the user picks.
+  private micChannel: AudioWsStream | null = null;
+
   async start(
     audioInputDeviceName: string,
     sessionToken: string,
@@ -409,6 +442,7 @@ class LiveTranscriptionService {
 
     const micChannel = new AudioWsStream('ch_1', this.micStream, language, onTranscript);
     const loopbackChannel = new AudioWsStream('ch_0', this.loopbackStream, language, onTranscript);
+    this.micChannel = micChannel;
     this.channels = [micChannel, loopbackChannel];
     await Promise.all(this.channels.map((channel) => channel.start()));
   }
@@ -431,9 +465,52 @@ class LiveTranscriptionService {
     if (failed) throw failed.reason;
   }
 
+  /**
+   * Switch the microphone mid-session.
+   *
+   * A no-op when nothing is running: `micChannel` is null until start(), and start() resolves
+   * the device from the config store itself, so a change made while stopped is already applied
+   * by the time anything reads it.
+   *
+   * The new stream is acquired *before* anything is torn down, and the old one is stopped only
+   * once the swap has succeeded. A device that is unplugged, in use, or refused by permissions
+   * therefore leaves the session running on the microphone it already had, which is the whole
+   * reason this is not a stop-and-start. Only ch_1 moves; ch_0 is loopback audio from the call.
+   */
+  async setAudioInputDevice(deviceName: string): Promise<void> {
+    const channel = this.micChannel;
+    if (!channel) return;
+
+    const deviceId = await this.resolveMicDeviceId(deviceName);
+    const nextStream = await navigator.mediaDevices.getUserMedia({
+      audio: deviceId ? { deviceId: { exact: deviceId } } : true,
+      video: false,
+    });
+
+    // Stopped while getUserMedia was resolving. Releasing the stream here matters: nothing else
+    // holds a reference to it, so the device would stay open with its indicator light on for the
+    // life of the app.
+    if (this.micChannel !== channel) {
+      nextStream.getTracks().forEach((track) => track.stop());
+      return;
+    }
+
+    const previous = this.micStream;
+    try {
+      await channel.setStream(nextStream);
+    } catch (error) {
+      nextStream.getTracks().forEach((track) => track.stop());
+      throw error;
+    }
+
+    this.micStream = nextStream;
+    previous?.getTracks().forEach((track) => track.stop());
+  }
+
   async stop(): Promise<void> {
     await Promise.all(this.channels.map((channel) => channel.stop()));
     this.channels = [];
+    this.micChannel = null;
 
     this.micStream?.getTracks().forEach((track) => track.stop());
     this.loopbackStream?.getTracks().forEach((track) => track.stop());

--- a/src/renderer/services/live-transcription.service.ts
+++ b/src/renderer/services/live-transcription.service.ts
@@ -1,4 +1,5 @@
 import { getElectron } from '@/lib/utils';
+import { DEFAULT_LANGUAGE, Language } from '@/types/language';
 
 const SAMPLE_RATE = 16000;
 const MAX_WS_BUFFERED_BYTES = SAMPLE_RATE * 0.3;
@@ -11,6 +12,18 @@ const BACKEND_BASE_URL = import.meta.env.DEV
   ? 'http://localhost:8080'
   : 'https://api.powerinterviewai.com';
 const STREAMING_URL = `${BACKEND_BASE_URL.replace('http', 'ws')}/api/asr/streaming`;
+
+/**
+ * The streaming URL for one channel.
+ *
+ * English is sent as no parameter at all rather than as `language=en`. The backend treats an
+ * absent language as English and builds the AssemblyAI URL it has always built, so an English
+ * session stays byte-identical to what shipped before the picker existed.
+ */
+function buildStreamingUrl(language: Language): string {
+  if (language === DEFAULT_LANGUAGE) return STREAMING_URL;
+  return `${STREAMING_URL}?language=${encodeURIComponent(language)}`;
+}
 
 // Inline AudioWorklet processor (runs off the main thread)
 const AUDIO_WORKLET_CODE = `
@@ -53,9 +66,15 @@ class AudioWsStream {
   private stopping = false;
   private reconnectTimer: number | null = null;
 
+  // Set while setLanguage() is tearing the socket down and bringing it back. The close it
+  // causes is not a disconnect, so the ordinary reconnect must not also fire: two connects in
+  // flight leave one socket orphaned and still relaying audio into a dead session.
+  private switching = false;
+
   constructor(
     private readonly channel: Channel,
     private readonly stream: MediaStream,
+    private language: Language,
     private readonly onTranscript: (payload: {
       channel: Channel;
       type: 'partial' | 'final';
@@ -136,6 +155,37 @@ class AudioWsStream {
     this.ws = null;
   }
 
+  /**
+   * Re-open this channel's socket on a different language.
+   *
+   * The language is a connection parameter, so there is no way to change it in place: the socket
+   * has to go and come back. That costs a gap of a second or two in this channel's transcription
+   * and orphans whatever utterance was mid-flight, which is why the caller is expected to be a
+   * deliberate user action rather than anything automatic.
+   */
+  async setLanguage(language: Language): Promise<void> {
+    if (language === this.language) return;
+    this.language = language;
+
+    // Not started yet, or already stopped: start() reads the field, so there is nothing to do.
+    if (!this.active || this.stopping) return;
+
+    this.switching = true;
+    try {
+      // Cancel a pending backoff reconnect first, or it wakes up later and opens a second socket.
+      if (this.reconnectTimer !== null) {
+        window.clearTimeout(this.reconnectTimer);
+        this.reconnectTimer = null;
+      }
+      if (this.ws && this.ws.readyState < WebSocket.CLOSING) {
+        this.ws.close();
+      }
+      await this.connectWithRetry();
+    } finally {
+      this.switching = false;
+    }
+  }
+
   private async connectWithRetry(): Promise<void> {
     let lastError: unknown;
     for (let attempt = 0; attempt < WS_RETRY_MAX_ATTEMPTS; attempt++) {
@@ -166,7 +216,9 @@ class AudioWsStream {
 
   private connectWebSocket(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      const ws = new WebSocket(STREAMING_URL);
+      // Rebuilt per attempt rather than captured once, so a reconnect cannot outlive the
+      // language the session opened with.
+      const ws = new WebSocket(buildStreamingUrl(this.language));
       this.ws = ws;
       let settled = false;
 
@@ -219,12 +271,21 @@ class AudioWsStream {
 
     ws.onclose = () => {
       if (this.stopping || !this.active) return;
+      // A close from a socket that is no longer the current one is not a disconnect; it is the
+      // tail of a replacement that already happened. Reconnecting on it would clobber the live
+      // socket with a second one.
+      if (this.ws !== ws) return;
 
       // A reconnect starts a fresh backend session, so any in-flight utterance never gets its
-      // final. Tell main to close it out, or the orphaned partial gates live suggestions.
+      // final. Tell main to close it out, or the orphaned partial gates live suggestions. A
+      // language switch is a reconnect too, so this holds for it as well.
       getElectron()
         ?.transcription.channelDisconnected(this.channel)
         .catch((error) => console.error('Failed to report channel disconnect:', error));
+
+      // setLanguage owns the reconnect in that case, and does it immediately rather than after
+      // the backoff delay this would wait out.
+      if (this.switching) return;
 
       this.scheduleReconnect();
     };
@@ -275,7 +336,11 @@ class LiveTranscriptionService {
   private loopbackStream: MediaStream | null = null;
   private channels: AudioWsStream[] = [];
 
-  async start(audioInputDeviceName: string, sessionToken: string): Promise<void> {
+  async start(
+    audioInputDeviceName: string,
+    sessionToken: string,
+    language: Language = DEFAULT_LANGUAGE
+  ): Promise<void> {
     const electron = getElectron();
     if (!electron) throw new Error('Electron API not available');
     await electron.transcription.setSessionToken(sessionToken);
@@ -316,10 +381,21 @@ class LiveTranscriptionService {
       await electron.transcription.ingest(payload);
     };
 
-    const micChannel = new AudioWsStream('ch_1', this.micStream, onTranscript);
-    const loopbackChannel = new AudioWsStream('ch_0', this.loopbackStream, onTranscript);
+    const micChannel = new AudioWsStream('ch_1', this.micStream, language, onTranscript);
+    const loopbackChannel = new AudioWsStream('ch_0', this.loopbackStream, language, onTranscript);
     this.channels = [micChannel, loopbackChannel];
     await Promise.all(this.channels.map((channel) => channel.start()));
+  }
+
+  /**
+   * Switch both channels to a new language mid-session.
+   *
+   * A no-op when nothing is running: the channels array is empty until start(), and start()
+   * takes the language it is called with. Suggestions need no equivalent - every request reads
+   * the config store when it is built, so the next one already follows the new setting.
+   */
+  async setLanguage(language: Language): Promise<void> {
+    await Promise.all(this.channels.map((channel) => channel.setLanguage(language)));
   }
 
   async stop(): Promise<void> {

--- a/src/renderer/services/live-transcription.service.ts
+++ b/src/renderer/services/live-transcription.service.ts
@@ -167,21 +167,28 @@ class AudioWsStream {
    * are still feeding the graph until the source below is replaced.
    */
   async setStream(stream: MediaStream): Promise<void> {
-    // No graph yet: start() has not run, or stop() tore it down. Recording the stream is enough,
-    // since start() reads the field.
-    if (!this.ctx || !this.workletNode) {
-      this.stream = stream;
-      return;
-    }
-
-    this.source?.disconnect();
     this.stream = stream;
+
+    // No context yet: start() has not reached one, or stop() tore it down. The field above is
+    // enough, because start() builds its source from it.
+    if (!this.ctx) return;
+
+    // Deliberately **not** also gated on `workletNode`. start() creates `source` from
+    // `this.stream` and only assigns `workletNode` after `await addModule()`, so there is a real
+    // window where a context and a source exist and the node does not. Returning early there
+    // would leave `source` bound to the stream the caller is about to stop, and start() would
+    // then wire that dead source into the graph - a channel that relays silence for the rest of
+    // the session, with the socket up and nothing to show it went wrong.
+    this.source?.disconnect();
 
     // Built on the existing AudioContext on purpose. Its sampleRate is fixed at construction and
     // `convertTo16kPcm` reads it, so making a new context here would silently resample against
     // the wrong rate; `createMediaStreamSource` handles a device that runs at another rate.
     this.source = this.ctx.createMediaStreamSource(stream);
-    this.source.connect(this.workletNode);
+
+    // Only if the node is already there. If it is not, start() has not reached its own
+    // `source.connect(workletNode)` yet, and that line reads `this.source` - which is now this one.
+    if (this.workletNode) this.source.connect(this.workletNode);
   }
 
   /**

--- a/src/renderer/services/live-transcription.service.ts
+++ b/src/renderer/services/live-transcription.service.ts
@@ -167,8 +167,11 @@ class AudioWsStream {
     if (language === this.language) return;
     this.language = language;
 
-    // Not started yet, or already stopped: start() reads the field, so there is nothing to do.
-    if (!this.active || this.stopping) return;
+    // Keyed on the socket rather than on `active`, which start() only sets *after* its first
+    // connect returns. In that window a socket already exists on the old language and would
+    // never be reconnected, leaving the channel transcribing in a language nobody selected.
+    // No socket means start() has not run or stop() has cleared it, and start() reads the field.
+    if (this.stopping || !this.ws) return;
 
     this.switching = true;
     try {
@@ -180,10 +183,38 @@ class AudioWsStream {
       if (this.ws && this.ws.readyState < WebSocket.CLOSING) {
         this.ws.close();
       }
+      // Reported here rather than left to onclose. `new WebSocket` below assigns `this.ws`
+      // synchronously, so by the time the old socket's close event fires it is no longer the
+      // current one and that handler correctly ignores it - which would swallow this too, and
+      // leave the orphaned partial gating live suggestions for the rest of the session.
+      this.reportDisconnected();
       await this.connectWithRetry();
+    } catch (error) {
+      // Stopped while the new socket was coming up. That is the assistant shutting down, not a
+      // failed switch, and reporting it would toast an error over a deliberate action.
+      if (this.stopping) return;
+
+      // Hand the channel back to the ordinary backoff loop before reporting. Five failed
+      // attempts is a provider or network problem, not a permanent one, and without this the
+      // channel stays silent until the assistant is stopped and started - a worse outcome than
+      // the language change the user asked for simply taking longer to land.
+      this.scheduleReconnect();
+      throw error;
     } finally {
       this.switching = false;
     }
+  }
+
+  /**
+   * Tell main this channel's session ended mid-utterance.
+   *
+   * A reconnect - dropped or deliberate - starts a fresh backend session, so any in-flight
+   * utterance never gets its final, and the orphaned partial gates live suggestions.
+   */
+  private reportDisconnected(): void {
+    getElectron()
+      ?.transcription.channelDisconnected(this.channel)
+      .catch((error) => console.error('Failed to report channel disconnect:', error));
   }
 
   private async connectWithRetry(): Promise<void> {
@@ -276,15 +307,10 @@ class AudioWsStream {
       // socket with a second one.
       if (this.ws !== ws) return;
 
-      // A reconnect starts a fresh backend session, so any in-flight utterance never gets its
-      // final. Tell main to close it out, or the orphaned partial gates live suggestions. A
-      // language switch is a reconnect too, so this holds for it as well.
-      getElectron()
-        ?.transcription.channelDisconnected(this.channel)
-        .catch((error) => console.error('Failed to report channel disconnect:', error));
+      this.reportDisconnected();
 
-      // setLanguage owns the reconnect in that case, and does it immediately rather than after
-      // the backoff delay this would wait out.
+      // setLanguage owns both the report and the reconnect for the close it caused itself, and
+      // reconnects immediately rather than after the backoff delay this would wait out.
       if (this.switching) return;
 
       this.scheduleReconnect();
@@ -395,7 +421,14 @@ class LiveTranscriptionService {
    * the config store when it is built, so the next one already follows the new setting.
    */
   async setLanguage(language: Language): Promise<void> {
-    await Promise.all(this.channels.map((channel) => channel.setLanguage(language)));
+    // allSettled, not all: `all` rejects on the first failure and leaves the other channel's
+    // rejection unhandled, which surfaces as an unhandledrejection rather than as this throw.
+    const results = await Promise.allSettled(
+      this.channels.map((channel) => channel.setLanguage(language))
+    );
+
+    const failed = results.find((result) => result.status === 'rejected');
+    if (failed) throw failed.reason;
   }
 
   async stop(): Promise<void> {

--- a/src/renderer/services/live-transcription.service.ts
+++ b/src/renderer/services/live-transcription.service.ts
@@ -17,8 +17,8 @@ const STREAMING_URL = `${BACKEND_BASE_URL.replace('http', 'ws')}/api/asr/streami
  * The streaming URL for one channel.
  *
  * English is sent as no parameter at all rather than as `language=en`. The backend treats an
- * absent language as English and builds the AssemblyAI URL it has always built, so an English
- * session stays byte-identical to what shipped before the picker existed.
+ * absent language as English, so an English session stays byte-identical to what shipped before
+ * the picker existed - which is what the request looks like from every client released before it.
  */
 function buildStreamingUrl(language: Language): string {
   if (language === DEFAULT_LANGUAGE) return STREAMING_URL;

--- a/src/renderer/types/config.ts
+++ b/src/renderer/types/config.ts
@@ -1,10 +1,10 @@
+import type { Language } from './language';
 import type { LLMConfig } from './llm';
 
-export enum Language {
-  English = 'en',
-}
+export type { Language };
 
 export interface Config {
+  // Interview language: what the ASR transcribes and what suggestions come back in.
   language: Language;
 
   // Authentication

--- a/src/renderer/types/language.ts
+++ b/src/renderer/types/language.ts
@@ -1,0 +1,43 @@
+/**
+ * Mirrors `Language` in src/main/types/language.ts, which mirrors the backend enum in turn.
+ */
+export enum Language {
+  English = 'en',
+  Spanish = 'es',
+  German = 'de',
+  French = 'fr',
+  Portuguese = 'pt',
+  Italian = 'it',
+}
+
+export const DEFAULT_LANGUAGE = Language.English;
+
+export interface LanguageOption {
+  code: Language;
+  /** English name, for a user who has not found their language in the list yet. */
+  name: string;
+  /** Endonym. Someone whose app is in the wrong language recognises this one first. */
+  nativeName: string;
+  /** Two letters for the control bar, so the current language is readable without opening it. */
+  short: string;
+}
+
+/**
+ * Display order is the order of the enum, not alphabetical by either name: alphabetical differs
+ * per naming column, so one of the two would always read as scrambled.
+ */
+export const LANGUAGES: readonly LanguageOption[] = [
+  { code: Language.English, name: 'English', nativeName: 'English', short: 'EN' },
+  { code: Language.Spanish, name: 'Spanish', nativeName: 'Español', short: 'ES' },
+  { code: Language.German, name: 'German', nativeName: 'Deutsch', short: 'DE' },
+  { code: Language.French, name: 'French', nativeName: 'Français', short: 'FR' },
+  { code: Language.Portuguese, name: 'Portuguese', nativeName: 'Português', short: 'PT' },
+  { code: Language.Italian, name: 'Italian', nativeName: 'Italiano', short: 'IT' },
+];
+
+const BY_CODE = new Map<string, LanguageOption>(LANGUAGES.map((option) => [option.code, option]));
+
+/** The option for a stored code, falling back to English for one this build does not know. */
+export function getLanguageOption(code: string | null | undefined): LanguageOption {
+  return (code ? BY_CODE.get(code) : undefined) ?? BY_CODE.get(DEFAULT_LANGUAGE)!;
+}

--- a/src/renderer/types/language.ts
+++ b/src/renderer/types/language.ts
@@ -8,6 +8,28 @@ export enum Language {
   French = 'fr',
   Portuguese = 'pt',
   Italian = 'it',
+  Dutch = 'nl',
+  Polish = 'pl',
+  Russian = 'ru',
+  Ukrainian = 'uk',
+  Czech = 'cs',
+  Romanian = 'ro',
+  Greek = 'el',
+  Hungarian = 'hu',
+  Swedish = 'sv',
+  Danish = 'da',
+  Norwegian = 'no',
+  Finnish = 'fi',
+  Turkish = 'tr',
+  Hindi = 'hi',
+  Japanese = 'ja',
+  Korean = 'ko',
+  Chinese = 'zh',
+  Vietnamese = 'vi',
+  Thai = 'th',
+  Indonesian = 'id',
+  Arabic = 'ar',
+  Hebrew = 'he',
 }
 
 export const DEFAULT_LANGUAGE = Language.English;
@@ -25,6 +47,10 @@ export interface LanguageOption {
 /**
  * Display order is the order of the enum, not alphabetical by either name: alphabetical differs
  * per naming column, so one of the two would always read as scrambled.
+ *
+ * `short` is the uppercased ISO code rather than anything derived from the name, which is what
+ * keeps it two characters wide for every entry - the trigger reserves that much and no more, and
+ * a three-letter label there would push the control out of the bar's rhythm.
  */
 export const LANGUAGES: readonly LanguageOption[] = [
   { code: Language.English, name: 'English', nativeName: 'English', short: 'EN' },
@@ -33,6 +59,28 @@ export const LANGUAGES: readonly LanguageOption[] = [
   { code: Language.French, name: 'French', nativeName: 'Français', short: 'FR' },
   { code: Language.Portuguese, name: 'Portuguese', nativeName: 'Português', short: 'PT' },
   { code: Language.Italian, name: 'Italian', nativeName: 'Italiano', short: 'IT' },
+  { code: Language.Dutch, name: 'Dutch', nativeName: 'Nederlands', short: 'NL' },
+  { code: Language.Polish, name: 'Polish', nativeName: 'Polski', short: 'PL' },
+  { code: Language.Russian, name: 'Russian', nativeName: 'Русский', short: 'RU' },
+  { code: Language.Ukrainian, name: 'Ukrainian', nativeName: 'Українська', short: 'UK' },
+  { code: Language.Czech, name: 'Czech', nativeName: 'Čeština', short: 'CS' },
+  { code: Language.Romanian, name: 'Romanian', nativeName: 'Română', short: 'RO' },
+  { code: Language.Greek, name: 'Greek', nativeName: 'Ελληνικά', short: 'EL' },
+  { code: Language.Hungarian, name: 'Hungarian', nativeName: 'Magyar', short: 'HU' },
+  { code: Language.Swedish, name: 'Swedish', nativeName: 'Svenska', short: 'SV' },
+  { code: Language.Danish, name: 'Danish', nativeName: 'Dansk', short: 'DA' },
+  { code: Language.Norwegian, name: 'Norwegian', nativeName: 'Norsk', short: 'NO' },
+  { code: Language.Finnish, name: 'Finnish', nativeName: 'Suomi', short: 'FI' },
+  { code: Language.Turkish, name: 'Turkish', nativeName: 'Türkçe', short: 'TR' },
+  { code: Language.Hindi, name: 'Hindi', nativeName: 'हिन्दी', short: 'HI' },
+  { code: Language.Japanese, name: 'Japanese', nativeName: '日本語', short: 'JA' },
+  { code: Language.Korean, name: 'Korean', nativeName: '한국어', short: 'KO' },
+  { code: Language.Chinese, name: 'Chinese', nativeName: '中文', short: 'ZH' },
+  { code: Language.Vietnamese, name: 'Vietnamese', nativeName: 'Tiếng Việt', short: 'VI' },
+  { code: Language.Thai, name: 'Thai', nativeName: 'ไทย', short: 'TH' },
+  { code: Language.Indonesian, name: 'Indonesian', nativeName: 'Bahasa Indonesia', short: 'ID' },
+  { code: Language.Arabic, name: 'Arabic', nativeName: 'العربية', short: 'AR' },
+  { code: Language.Hebrew, name: 'Hebrew', nativeName: 'עברית', short: 'HE' },
 ];
 
 const BY_CODE = new Map<string, LanguageOption>(LANGUAGES.map((option) => [option.code, option]));

--- a/test/audio-device-switch.test.mjs
+++ b/test/audio-device-switch.test.mjs
@@ -1,0 +1,92 @@
+/**
+ * Microphone switching is renderer code, and the renderer has no runtime harness here - every
+ * other test in this directory loads a built main-process module. So these are source-level
+ * checks on `live-transcription.service.ts`, and they are worth the awkwardness because the
+ * invariant they cover is an ordering one that a later tidy-up would break without any symptom
+ * a type checker or a linter can see.
+ *
+ * The failure being guarded against: stopping the old microphone before the replacement is
+ * acquired. It reads as the obvious cleanup order, it works whenever the new device is present,
+ * and on the one path that matters - a device that is unplugged, held by another app, or refused
+ * by permissions - it leaves the interview with no microphone at all, mid-answer, having been
+ * asked only to change one.
+ */
+import { readFileSync } from 'node:fs';
+
+import { createChecker } from './helpers.mjs';
+
+function methodBody(source, signature) {
+  const start = source.indexOf(signature);
+  if (start === -1) return '';
+
+  // Walk braces from the signature's opening brace to its match.
+  const open = source.indexOf('{', start);
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(open, i + 1);
+    }
+  }
+  return '';
+}
+
+export async function run() {
+  const { check, failures } = createChecker('audio-device-switch');
+
+  const source = readFileSync(
+    new URL('../src/renderer/services/live-transcription.service.ts', import.meta.url),
+    'utf8'
+  );
+
+  const body = methodBody(source, 'async setAudioInputDevice(');
+  check('setAudioInputDevice exists', body.length > 0);
+
+  const acquire = body.indexOf('getUserMedia');
+  const swap = body.indexOf('channel.setStream');
+  const stopPrevious = body.indexOf('previous?.getTracks()');
+
+  check('the replacement stream is acquired', acquire !== -1);
+  check('the channel is handed the new stream', swap !== -1);
+  check('the previous stream is stopped', stopPrevious !== -1);
+
+  // The whole point. Acquire, then swap, then release - never release first.
+  check('the new device is acquired before the graph is touched', acquire < swap);
+  check('the old device is released only after the swap', swap < stopPrevious);
+
+  // Without this the session goes on holding a device nobody is reading from, indicator light
+  // included, because nothing else keeps a reference to the stream that was being opened.
+  check(
+    'a stream acquired after teardown is released rather than leaked',
+    body.includes('this.micChannel !== channel')
+  );
+
+  // A no-op while stopped, rather than an error: start() resolves the device from the config
+  // store itself, so a change made while nothing runs is already applied when it next reads.
+  check('a device change while stopped is a no-op', /if \(!channel\) return;/.test(body));
+
+  // The socket carries the language, not the device, so a microphone change must not reconnect.
+  // Reaching for setLanguage's machinery here would reintroduce the gap this avoids.
+  check(
+    'switching the microphone does not reconnect the socket',
+    !body.includes('connectWithRetry') && !body.includes('reportDisconnected')
+  );
+
+  const setStream = methodBody(source, 'async setStream(');
+  check('setStream exists', setStream.length > 0);
+
+  // `convertTo16kPcm` reads ctx.sampleRate, which is fixed when the context is constructed, so a
+  // fresh context here would resample every frame against the wrong rate - quietly, and only for
+  // users whose second device runs at a different rate than their first.
+  check(
+    'the existing AudioContext is reused rather than rebuilt',
+    !setStream.includes('new AudioContext')
+  );
+  check(
+    'the new source is wired back into the existing worklet',
+    setStream.includes('this.source.connect(this.workletNode)')
+  );
+
+  return failures;
+}

--- a/test/audio-device-switch.test.mjs
+++ b/test/audio-device-switch.test.mjs
@@ -15,6 +15,15 @@ import { readFileSync } from 'node:fs';
 
 import { createChecker } from './helpers.mjs';
 
+/**
+ * Comments in this file explain the very patterns these checks forbid, so a naive substring
+ * search finds the prose rather than the code and fails on a correct implementation.
+ */
+function codeOnly(source) {
+  // `.` already excludes newlines in JS, so the line-comment pattern needs no escape for one.
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*/g, '');
+}
+
 function methodBody(source, signature) {
   const start = source.indexOf(signature);
   if (start === -1) return '';
@@ -74,6 +83,7 @@ export async function run() {
   );
 
   const setStream = methodBody(source, 'async setStream(');
+  const setStreamCode = codeOnly(setStream);
   check('setStream exists', setStream.length > 0);
 
   // `convertTo16kPcm` reads ctx.sampleRate, which is fixed when the context is constructed, so a
@@ -81,11 +91,34 @@ export async function run() {
   // users whose second device runs at a different rate than their first.
   check(
     'the existing AudioContext is reused rather than rebuilt',
-    !setStream.includes('new AudioContext')
+    !codeOnly(setStream).includes('new AudioContext')
   );
   check(
     'the new source is wired back into the existing worklet',
-    setStream.includes('this.source.connect(this.workletNode)')
+    setStreamCode.includes('this.source.connect(this.workletNode)')
+  );
+
+  // start() builds `source` from `this.stream`, then awaits addModule() before assigning
+  // `workletNode`. An early return covering that window leaves `source` bound to the stream the
+  // caller is about to stop, and start() then wires that dead source into the graph: the socket
+  // stays up, the channel relays silence, and nothing reports it. So the bail-out may test the
+  // context and must not also test the node.
+  const bailout = setStreamCode.slice(0, setStreamCode.indexOf('this.source?.disconnect()'));
+  check('setStream bails out on a missing context', bailout.includes('if (!this.ctx) return'));
+  check('the bail-out is not also gated on the worklet node', !bailout.includes('workletNode'));
+
+  // Assigned before that bail-out, or a swap made before start() reaches a context is dropped -
+  // start() reads the field, so recording it is the whole job on that path.
+  check(
+    'the stream is recorded before any early return',
+    setStreamCode.indexOf('this.stream = stream') < setStreamCode.indexOf('if (!this.ctx) return')
+  );
+
+  // The connect is conditional for the same window: start() has its own
+  // `source.connect(workletNode)` and reads `this.source`, which is the replacement by then.
+  check(
+    'the worklet connect is guarded rather than assumed',
+    /if \(this\.workletNode\) this\.source\.connect\(this\.workletNode\)/.test(setStreamCode)
   );
 
   return failures;

--- a/test/helpers.mjs
+++ b/test/helpers.mjs
@@ -31,11 +31,21 @@ export function stubElectron() {
 // Records every Dock/activation-policy call in order so the macOS surface can be asserted on
 // any platform. See test/stealth-dock.test.mjs.
 const dockCalls = [];
+// Every app.on(...) registration, so a test can fire the event the module under test is
+// waiting for. See test/navigation-guard.test.mjs.
+const appListeners = new Map();
 const app = {
   getPath: () => ${JSON.stringify(userData)},
   getName: () => 'pia-test',
   getVersion: () => '0.0.0',
-  on: () => {},
+  on: (event, handler) => {
+    if (!appListeners.has(event)) appListeners.set(event, []);
+    appListeners.get(event).push(handler);
+  },
+  emit: (event, ...args) => {
+    for (const handler of appListeners.get(event) ?? []) handler(...args);
+  },
+  appListeners,
   whenReady: () => Promise.resolve(),
   setActivationPolicy: (policy) => dockCalls.push(policy),
   dock: {
@@ -46,7 +56,14 @@ const app = {
 };
 const ipcMain = { on: () => {}, handle: () => {} };
 const screen = { getPrimaryDisplay: () => ({ workAreaSize: { width: 1920, height: 1080 } }), getAllDisplays: () => [] };
-const shell = { openPath: async () => '' };
+// Records what was handed to the OS, so a test can assert that a blocked scheme never reaches it.
+const openExternalCalls = [];
+const shell = {
+  openPath: async () => '',
+  openExternal: async (url) => { openExternalCalls.push(url); },
+  openExternalCalls,
+  showItemInFolder: () => {},
+};
 export { app, ipcMain, screen, shell };
 export default { app, ipcMain, screen, shell };`,
       };

--- a/test/language.test.mjs
+++ b/test/language.test.mjs
@@ -1,0 +1,50 @@
+/**
+ * The interview language decides which speech model transcribes the audio, and that failure is
+ * silent: universal-streaming-english does not report a language it cannot handle, it returns
+ * confident English words for speech that was never English. So the two things worth pinning are
+ * that a stored language actually reaches the request bodies, and that an unknown one resolves to
+ * English here rather than travelling to the backend and the ASR URL.
+ */
+import { createChecker, loadMain } from './helpers.mjs';
+
+export async function run() {
+  const { check, failures } = createChecker('language');
+
+  const { Language, DEFAULT_LANGUAGE, resolveLanguage } = await loadMain('types/language.js');
+  const { configStore } = await loadMain('store/config.store.js');
+
+  check('English is the default', DEFAULT_LANGUAGE === 'en');
+  check(
+    'the set is the six universal-streaming-multilingual covers',
+    JSON.stringify(Object.values(Language).sort()) ===
+      JSON.stringify(['de', 'en', 'es', 'fr', 'it', 'pt'])
+  );
+
+  // Absent, blank and unknown all resolve rather than throwing or passing through. A code this
+  // build does not know reaching the ASR URL is the case that matters: the backend can only fall
+  // back anyway, and in the meantime the picker renders a blank trigger.
+  check('absent resolves to English', resolveLanguage(undefined) === 'en');
+  check('null resolves to English', resolveLanguage(null) === 'en');
+  check('empty resolves to English', resolveLanguage('') === 'en');
+  check('an unknown code resolves to English', resolveLanguage('kl') === 'en');
+  check('a regional variant resolves to English', resolveLanguage('en-GB') === 'en');
+  check('a known code is kept', resolveLanguage('es') === 'es');
+  check('case and whitespace are normalised', resolveLanguage(' ES ') === 'es');
+
+  // The store is the single source for every consumer, so it is where an unknown code has to die.
+  configStore.updateConfig({ language: 'de' });
+  check('a chosen language round-trips', configStore.getConfig().language === 'de');
+
+  // Written straight to the raw object: updateConfig is typed, and the case being covered is a
+  // value some other build left on disk.
+  const raw = configStore.getStoredRuntime() ?? {};
+  configStore.setStoredRuntime({ ...raw, language: 'kl' });
+  check(
+    'getConfig resolves a stored language this build does not know',
+    configStore.getConfig().language === 'en'
+  );
+
+  configStore.updateConfig({ language: 'en' });
+
+  return failures;
+}

--- a/test/language.test.mjs
+++ b/test/language.test.mjs
@@ -5,6 +5,8 @@
  * that a stored language actually reaches the request bodies, and that an unknown one resolves to
  * English here rather than travelling to the backend and the ASR URL.
  */
+import { readFileSync } from 'node:fs';
+
 import { createChecker, loadMain } from './helpers.mjs';
 
 export async function run() {
@@ -14,10 +16,42 @@ export async function run() {
   const { configStore } = await loadMain('store/config.store.js');
 
   check('English is the default', DEFAULT_LANGUAGE === 'en');
+
+  // The set used to be pinned as a literal six, because that is all
+  // universal-streaming-multilingual transcribes. The ceiling is now what the backend's Deepgram
+  // provider streams, so the literal moved rather than the rule: the picker must never offer a
+  // language the ASR cannot hear.
+  check('English is in the set', Object.values(Language).includes('en'));
   check(
-    'the set is the six universal-streaming-multilingual covers',
-    JSON.stringify(Object.values(Language).sort()) ===
-      JSON.stringify(['de', 'en', 'es', 'fr', 'it', 'pt'])
+    'every code is a bare lowercase ISO 639-1 pair',
+    Object.values(Language).every((code) => /^[a-z]{2}$/.test(code))
+  );
+  check(
+    'no code is listed twice',
+    new Set(Object.values(Language)).size === Object.values(Language).length
+  );
+
+  // The enum is mirrored into the renderer, which carries the display metadata the picker reads.
+  // Drift is the failure this catches, and it is silent in both directions: an enum member with
+  // no renderer entry renders a blank trigger, and a renderer entry with no enum member is an
+  // option that resolves straight back to English when picked. The renderer source is read as
+  // text because it is never built into electron-dist, which is all `loadMain` can reach.
+  const rendererSource = readFileSync(
+    new URL('../src/renderer/types/language.ts', import.meta.url),
+    'utf8'
+  );
+  const rendererCodes = [...rendererSource.matchAll(/code: Language\.\w+, name: '/g)].length;
+  const rendererEnum = [...rendererSource.matchAll(/^  \w+ = '([a-z]{2})',$/gm)].map((m) => m[1]);
+
+  check(
+    'the renderer mirrors every code in the main enum',
+    JSON.stringify(rendererEnum.slice().sort()) ===
+      JSON.stringify(Object.values(Language).slice().sort())
+  );
+  check('the picker lists every language in the enum', rendererCodes === rendererEnum.length);
+  check(
+    'every picker entry carries a two-character short label',
+    [...rendererSource.matchAll(/short: '([^']*)'/g)].every((m) => m[1].length === 2)
   );
 
   // Absent, blank and unknown all resolve rather than throwing or passing through. A code this

--- a/test/language.test.mjs
+++ b/test/language.test.mjs
@@ -13,6 +13,7 @@ export async function run() {
   const { check, failures } = createChecker('language');
 
   const { Language, DEFAULT_LANGUAGE, resolveLanguage } = await loadMain('types/language.js');
+  const { transcriptSeparator } = await loadMain('utils/transcript-join.js');
   const { configStore } = await loadMain('store/config.store.js');
 
   check('English is the default', DEFAULT_LANGUAGE === 'en');
@@ -64,6 +65,20 @@ export async function run() {
   check('a regional variant resolves to English', resolveLanguage('en-GB') === 'en');
   check('a known code is kept', resolveLanguage('es') === 'es');
   check('case and whitespace are normalised', resolveLanguage(' ES ') === 'es');
+
+  // The backend already avoids putting spaces inside a Japanese utterance when it rejoins the
+  // segments Deepgram froze. transcript.service.ts merges whole transcripts that landed within
+  // TRANSCRIPT_INTER_TRANSCRIPT_GAP_MS of each other, and joining those with a space would put
+  // the defect straight back - in the panel, and in the text the suggestion request carries.
+  check('a spaced language merges with a space', transcriptSeparator('en') === ' ');
+  check('Spanish merges with a space', transcriptSeparator('es') === ' ');
+  check('Japanese merges with nothing', transcriptSeparator('ja') === '');
+  check('Chinese merges with nothing', transcriptSeparator('zh') === '');
+  check('Thai merges with nothing', transcriptSeparator('th') === '');
+  check(
+    'every unspaced language is one the picker actually offers',
+    ['ja', 'zh', 'th'].every((code) => Object.values(Language).includes(code))
+  );
 
   // The store is the single source for every consumer, so it is where an unknown code has to die.
   configStore.updateConfig({ language: 'de' });

--- a/test/language.test.mjs
+++ b/test/language.test.mjs
@@ -1,7 +1,7 @@
 /**
  * The interview language decides which speech model transcribes the audio, and that failure is
- * silent: universal-streaming-english does not report a language it cannot handle, it returns
- * confident English words for speech that was never English. So the two things worth pinning are
+ * silent: a model does not report a language it cannot handle, it returns confident words in one
+ * it can for speech that was never in that language. So the two things worth pinning are
  * that a stored language actually reaches the request bodies, and that an unknown one resolves to
  * English here rather than travelling to the backend and the ASR URL.
  */

--- a/test/navigation-guard.test.mjs
+++ b/test/navigation-guard.test.mjs
@@ -90,6 +90,22 @@ export async function run() {
     return prevented;
   };
 
+  // createWindow() runs again when the single-instance lock recovers a destroyed window, and
+  // web-contents-created is an app-level event, so a second install would stack a duplicate
+  // listener on every web contents from then on.
+  installNavigationGuard(APP_URL);
+  const laterHandlers = [];
+  const laterContents = {
+    setWindowOpenHandler: () => {},
+    on: (event, handler) => {
+      if (event === 'will-navigate') laterHandlers.push(handler);
+    },
+  };
+  electron.app.emit('web-contents-created', {}, laterContents);
+  // One, not two: a second install would leave two app-level listeners, and every web contents
+  // created from then on would get both.
+  check('installing twice registers nothing twice', laterHandlers.length === 1);
+
   check('the app may navigate within its own origin', !navigate(`${APP_URL}/index.html`));
   check('an off-origin navigation is blocked', navigate('https://example.com'));
   check('a file url is blocked', navigate('file:///etc/passwd'));

--- a/test/navigation-guard.test.mjs
+++ b/test/navigation-guard.test.mjs
@@ -1,0 +1,99 @@
+/**
+ * What the app's own web contents are allowed to navigate to, and what it hands to the OS.
+ *
+ * The panels render Markdown that came from a language model, and remark-gfm autolinks bare
+ * URLs, so an anchor in this app is not necessarily one a person wrote. Nothing here is about
+ * whether the model is hostile; it is about the app not having a route from generated text to
+ * "launch this" that nobody chose to build.
+ *
+ * Three properties, each of which fails silently and looks like a working link:
+ *
+ * A `target="_blank"` anchor asks Electron for a new window, and with no handler installed the
+ * default is to make one - a chromeless BrowserWindow with no address bar. Denied, and handed to
+ * the real browser instead.
+ *
+ * An anchor with no target navigates the frame it is in, and that frame is the app. Preload runs
+ * on whatever document loads next, so a remote page would inherit `window.electronAPI` and with
+ * it the session token via `config.get()` and the candidate's CV via `account.get()`.
+ *
+ * And `shell.openExternal` delegates to the OS protocol handler, so `file:` launches whatever the
+ * path points at. Only the three schemes that mean "show this to the user" get through.
+ */
+import { createChecker, loadMain } from './helpers.mjs';
+
+const APP_URL = 'http://localhost:15173';
+
+export async function run() {
+  const { check, failures } = createChecker('navigation-guard');
+
+  const electron = await import('electron');
+  const { isOpenableExternally, openExternally, installNavigationGuard } =
+    await loadMain('navigation-guard.js');
+
+  check('http is openable', isOpenableExternally('http://example.com/docs'));
+  check('https is openable', isOpenableExternally('https://example.com/docs'));
+  check('mailto is openable', isOpenableExternally('mailto:support@example.com'));
+
+  for (const url of [
+    'file:///C:/Windows/System32/calc.exe',
+    'file:///etc/passwd',
+    'javascript:alert(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'vscode://x',
+    'ms-msdt:/id',
+    'smb://server/share',
+    'not a url',
+    '',
+  ]) {
+    check(`refused: ${url || '(empty)'}`, !isOpenableExternally(url));
+  }
+
+  const before = electron.shell.openExternalCalls.length;
+  const refused = await openExternally('file:///etc/passwd');
+  check('openExternally reports the refusal', refused.success === false);
+  check('and never reaches the OS handler', electron.shell.openExternalCalls.length === before);
+
+  const allowed = await openExternally('https://example.com');
+  check('an http url is opened', allowed.success === true);
+  check(
+    'and is the one handed over',
+    electron.shell.openExternalCalls.at(-1) === 'https://example.com'
+  );
+
+  installNavigationGuard(APP_URL);
+
+  let windowOpenHandler;
+  const navigationHandlers = [];
+  const contents = {
+    setWindowOpenHandler: (handler) => {
+      windowOpenHandler = handler;
+    },
+    on: (event, handler) => {
+      if (event === 'will-navigate') navigationHandlers.push(handler);
+    },
+  };
+  electron.app.emit('web-contents-created', {}, contents);
+
+  check('a window-open handler is installed', typeof windowOpenHandler === 'function');
+  check('a will-navigate handler is installed', navigationHandlers.length === 1);
+
+  check(
+    'every new window is denied, whatever the url',
+    ['https://example.com', 'file:///etc/passwd', 'about:blank'].every(
+      (url) => windowOpenHandler({ url }).action === 'deny'
+    )
+  );
+
+  const navigate = (url) => {
+    let prevented = false;
+    navigationHandlers[0]({ preventDefault: () => (prevented = true) }, url);
+    return prevented;
+  };
+
+  check('the app may navigate within its own origin', !navigate(`${APP_URL}/index.html`));
+  check('an off-origin navigation is blocked', navigate('https://example.com'));
+  check('a file url is blocked', navigate('file:///etc/passwd'));
+  check('an unparseable url is blocked', navigate('not a url'));
+
+  return failures;
+}

--- a/test/run.mjs
+++ b/test/run.mjs
@@ -27,6 +27,7 @@ for (const module of [
   // reads the same running state through its own copy of window-control.
   './running-surface.test.mjs',
   './tools-export.test.mjs',
+  './audio-device-switch.test.mjs',
   './interviewer-turn.test.mjs',
   './transcript-turn-selection.test.mjs',
   './suggestion-sentinel.test.mjs',

--- a/test/run.mjs
+++ b/test/run.mjs
@@ -32,6 +32,7 @@ for (const module of [
   './suggestion-sentinel.test.mjs',
   './suggestion-emphasis.test.mjs',
   './suggestion-truncate.test.mjs',
+  './navigation-guard.test.mjs',
   './mac-update-util.test.mjs',
   './change-password.test.mjs',
   './password-reset.test.mjs',

--- a/test/run.mjs
+++ b/test/run.mjs
@@ -15,6 +15,9 @@ const userDataDir = stubElectron();
 const failures = [];
 for (const module of [
   './config-store.test.mjs',
+  // After config-store: that one seeds the store file and asserts on the leftover pre-sync
+  // config, and this one writes to the same store.
+  './language.test.mjs',
   './app-state.test.mjs',
   './account.test.mjs',
   './stealth-surface.test.mjs',

--- a/test/run.mjs
+++ b/test/run.mjs
@@ -31,6 +31,7 @@ for (const module of [
   './transcript-turn-selection.test.mjs',
   './suggestion-sentinel.test.mjs',
   './suggestion-emphasis.test.mjs',
+  './suggestion-truncate.test.mjs',
   './mac-update-util.test.mjs',
   './change-password.test.mjs',
   './password-reset.test.mjs',

--- a/test/suggestion-truncate.test.mjs
+++ b/test/suggestion-truncate.test.mjs
@@ -1,0 +1,74 @@
+/**
+ * `truncateMiddle` bounds the interviewer's question to the width the suggestion cards budget
+ * for it, and both panels called their own copy of it.
+ *
+ * Neither copy honoured the bound. Both reserved three characters for the separator and then
+ * spliced in thirteen, so every truncated question came back ten characters over the limit the
+ * caller had asked for - invisible on one line, and wrong for anything that reuses the helper to
+ * size something. The interesting half is which ten: the tail is what the caller is trying to
+ * keep (a question's actual ask is usually at the end of it), so the fix has to stay inside the
+ * budget without paying for it out of the tail alone.
+ *
+ * Loaded straight from the renderer source the way suggestion-emphasis.test.mjs is; the module
+ * has no imports and no runtime-only type syntax, so Node's type stripping handles it.
+ */
+import { createChecker } from './helpers.mjs';
+
+const SOURCE = new URL('../src/renderer/lib/suggestions.ts', import.meta.url);
+
+export async function run() {
+  const { check, failures } = createChecker('suggestion-truncate');
+
+  let truncateMiddle;
+  try {
+    ({ truncateMiddle } = await import(SOURCE.href));
+  } catch (e) {
+    if (/TypeScript|strip|Unknown file extension/i.test(String(e))) {
+      console.log('  skip  runtime cannot load TypeScript sources');
+      return failures;
+    }
+    throw e;
+  }
+
+  const trunc = truncateMiddle;
+
+  check(
+    'a short string is returned untouched',
+    trunc('Tell me about Kafka.', 256) === 'Tell me about Kafka.'
+  );
+  check('a string exactly at the limit is untouched', trunc('a'.repeat(64), 64) === 'a'.repeat(64));
+
+  // The bug this file exists for. 256 in, 266 out.
+  const long = 'q'.repeat(1000);
+  check('the result never exceeds the requested length', trunc(long, 256).length === 256);
+  check(
+    'and holds at other lengths too',
+    [10, 33, 64, 100, 257].every((n) => trunc(long, n).length === n)
+  );
+
+  check(
+    'the head is kept from the start',
+    trunc('abcdefghijklmnopqrstuvwxyz', 15).startsWith('abcde')
+  );
+  check('the tail is kept from the end', trunc('abcdefghijklmnopqrstuvwxyz', 15).endsWith('vwxyz'));
+  check('the middle is marked as dropped', trunc('abcdefghijklmnopqrstuvwxyz', 15).includes('...'));
+
+  // A question is truncated to keep its ask, which lives at the end. An odd budget has to leave
+  // that half intact rather than rounding it away.
+  check(
+    'an odd budget still keeps a tail',
+    [11, 13, 15, 21].every((n) => {
+      const out = trunc(long, n);
+      return out.length === n && out.endsWith('q');
+    })
+  );
+
+  // Degenerate budgets: no separator fits, so there is nothing to signal with, but the contract
+  // that the result fits still holds rather than the function returning a longer string.
+  check(
+    'a budget too small for the separator still bounds the result',
+    [0, 1, 3, 5].every((n) => trunc(long, n).length === n)
+  );
+
+  return failures;
+}


### PR DESCRIPTION
Closes #24.

`Language` had one member and was read by nothing. This makes it a real setting: a picker on the control bar that decides which speech model transcribes the call, what language suggestions are written in, and the language of the exported report - **changeable mid-interview**, not only before Start.

Since the first review this has grown two things, both driven by the backend moving its ASR to Deepgram Nova-3: the language set went from **6 to 28**, and the **microphone became switchable mid-interview** for the same reason the language is.

Pairs with PowerInterviewAI/backend#58. Neither side needs the other to ship: the backend defaults the field, so this client works against a deployment that predates it (suggestions stay English, and so does the transcription). A code this build knows but an older backend does not is resolved back to English there rather than faked, so a client ahead of its backend degrades one session instead of breaking it.

## What changed

| | |
| --- | --- |
| `src/main/types/language.ts`, `src/renderer/types/language.ts` | the enum, mirrored the way `SuggestionMode` is, plus display metadata |
| `src/main/store/config.store.ts` | `language` is typed and resolved on read |
| `src/main/services/suggestion-{live,action}.service.ts`, `tools.service.ts` | `language` on all three request bodies |
| `src/renderer/services/live-transcription.service.ts` | `?language=` on the ASR sockets, `setLanguage()` to switch them, and `setAudioInputDevice()` / `setStream()` to swap the microphone |
| `src/renderer/hooks/use-interview-language.ts` | the setter that reconciles the two halves |
| `src/renderer/hooks/use-audio-input-device.ts` | the same shape for the microphone |
| `src/renderer/components/custom/control-panel/language-group.tsx` | the language control |
| `src/renderer/components/custom/control-panel/audio-group.tsx` | the microphone control, now live mid-interview |

## The setting has two halves that move at different speeds

**Suggestions are free.** Each service reads the config store as it builds its request, so the next suggestion already follows a change - nothing to reconnect, nothing to wait for.

**The ASR is not.** The provider takes the language as a *connection* parameter, so switching means tearing both channels down and re-opening them: a second or two of gap, and whatever utterance was mid-flight is orphaned. `useInterviewLanguage` is where those two are reconciled, and the UI reports the difference rather than papering over it - the trigger spins while the sockets come back, and the menu says what will happen *before* the user commits, because a two-second hole in the transcript is alarming if it arrives unannounced mid-question.

This is a property of the provider, not a choice. Deepgram has no mid-stream language change at all, so the reconnect machinery below is now load-bearing rather than incidental.

## Two guards on the reconnect

Both protect against the same failure: two sockets on one channel, one of them orphaned and still relaying audio into a dead session. The existing `onclose` path schedules a backoff reconnect on any unexpected close, and a deliberate close for a language switch looks exactly like one.

- `onclose` now ignores a close from a socket that is no longer `this.ws`. That is the tail of a replacement, not a disconnect. (This one is a latent fix on the pre-existing reconnect path too.)
- `setLanguage` sets a `switching` flag so the backoff reconnect does not fire for the close it caused itself, and reconnects immediately instead of waiting out `WS_RETRY_BASE_DELAY_MS`.

`connectWebSocket` rebuilds the URL per attempt rather than capturing it, which is what lets a reconnect pick up the new language at all.

The first guard has two consequences worth calling out, both caught on review:

- **`setLanguage` reports `channelDisconnected` itself** rather than leaving it to `onclose`. `new WebSocket` assigns `this.ws` synchronously, so the old socket's close always arrives *after* its replacement exists and is correctly ignored - which would have swallowed the report too, leaving the orphaned partial gating live suggestions for the rest of the session.
- **Its no-op check keys on `this.ws`, not on `active`**, which `start()` sets only after its first connect returns. In that window a socket already exists on the old language and an `active` check would skip it.

A switch that cannot reconnect hands the channel back to the ordinary backoff loop rather than leaving it silent until the assistant is restarted - five failed attempts is a network or provider problem, not a permanent one - and the toast says it is still retrying. The two channels are switched with `allSettled`, since `Promise.all` leaves the second one's rejection unhandled.

## The microphone is now switchable too, and it is cheaper

The audio control used to lock while the assistant ran, which made the one case it exists for unreachable. A headset that dies, is unplugged, or was the wrong device to begin with is noticed exactly when the interviewer says they cannot hear you - and the only fix was stopping the assistant, which clears the transcript and the suggestion history with it.

**Nothing reconnects.** The device is only what feeds the worklet; it is *not* a connection parameter. `AudioWsStream.setStream()` replaces the `MediaStreamAudioSourceNode` while the socket, the provider session and any utterance in flight all survive, so there is no gap and the dialog promises the opposite of what the language menu warns about.

Three things it has to hold:

- **The replacement stream is acquired before anything is torn down**, and the previous one stopped only after the swap succeeds. Releasing first reads as the obvious cleanup order and works every time the new device is present; on the one path that matters - unplugged, in use, permissions refused - it leaves the session with no microphone at all, mid-answer, having been asked only to change one.
- **A stream that finishes opening after the session stopped is released**, not left holding the device with its indicator light on, since nothing else keeps a reference to it.
- **The existing `AudioContext` is reused.** Its `sampleRate` is fixed at construction and `convertTo16kPcm` reads it, so a fresh context would resample every frame against the wrong rate - quietly, and only for users whose second device runs at a different rate than their first.
- **The bail-out tests the context alone, never also the worklet node.** `start()` creates `source` from `this.stream` and only assigns `workletNode` after `await addModule()`, so there is a real window where a context and a source exist and the node does not. Returning early there leaves `source` bound to the stream the caller is about to stop, and `start()` then wires that dead source into the graph - socket up, channel relaying silence for the rest of the session, nothing reporting it. Caught on review after the first implementation had exactly that guard.

Only `ch_1` moves; `ch_0` is loopback audio from the call and has no device to change.

## Decisions worth arguing with

**English sends no parameter at all**, not `language=en`. The backend treats an absent language as English, so a session that never touches the picker produces byte-identical traffic to what shipped before this existed.

**The setting is persisted before the switch and never rolled back on failure**, for both controls. A failed reconnect that reverted the setting would leave the user with no route to the language they picked; leaving it set means stopping and starting the assistant recovers, and the toast says so. Same for the microphone, where a failed swap leaves the audio running on the previous device.

**Resolution happens on the way out of the config store, not on the way in.** The disk holds whatever some build wrote - a code a later release dropped, or one an older release never knew - and every consumer reads through `getConfig()`, so that is the single point where an unknown code can be stopped before it reaches the ASR URL and three request bodies.

**28 languages**, which is exactly what the backend's Deepgram Nova-3 ASR streams. It was six under the previous ASR. The rule did not change - offering one the ASR cannot hear would not degrade gracefully, it would answer a question that was never asked - only the ceiling did.

**Endonym first in the menu, English name second.** Someone whose interview has just switched language finds "Deutsch" faster than "German"; the English column is there for the reverse lookup. The trigger shows the code (`EN`, `ES`) next to the icon - a globe alone is only useful to someone who already knows what it is set to, which is the one question this control has to answer at a glance.

Two things the widening broke that six never exercised, both fixed here: the menu opens upward from the bottom-most control into an overflow-hidden `main`, so an uncapped 28-item list ran off the top of the window rather than flipping (it is now capped and scrolls); and the Arabic and Hebrew endonyms rendered into the menu's LTR flow, putting punctuation on the wrong side of the word (`dir="auto"`).

## Explicitly not in scope

Localising the app's own chrome - buttons, labels, dialogs, toasts. Separate feature, separate cost (~45 components plus every main-process error string), and not what makes the product unusable in Spanish today: an English button on a Spanish interview is an inconvenience, an English transcript of Spanish speech is a wrong answer read out loud.

## Testing

`pnpm lint`, both `tsc` configs, `pnpm build` and `pnpm test:main` all clean.

`test/language.test.mjs` now also pins **the two mirrors staying in step**, which is the failure the widening made likely and which is silent in both directions: an enum member with no picker entry renders a blank trigger, and a picker entry with no enum member resolves straight back to English when picked.

`test/audio-device-switch.test.mjs` pins the acquire-before-release ordering and the reused `AudioContext`. These are source-level checks, unusually for this directory - every other test loads a built main-process module, and this is renderer code with no runtime harness. They are worth the awkwardness because the ordering is exactly what a later tidy-up breaks, with no symptom a type checker or linter can see.

Not covered: the reconnect and the swap themselves. `AudioWsStream` needs a real `WebSocket`, `AudioContext` and `getDisplayMedia`, none of which the dependency-free main-process harness reaches. **Both are worth exercising by hand:**

- Change language during a running session; confirm the transcript resumes on the new language, exactly one socket per channel survives, and the card that was in flight is not left pending.
- Change microphone during a running session; confirm the transcript does *not* gap, and that picking a device that is unplugged mid-dialog leaves the interview running on the previous one.

